### PR TITLE
feat(project1): implement priority scheduling

### DIFF
--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -15,59 +15,57 @@
 #include "userprog/process.h"
 #endif
 
-/* Random value for struct thread's `magic' member.
-   Used to detect stack overflow.  See the big comment at the top
-   of thread.h for details. */
+/* struct thread의 `magic' 멤버에 넣는 임의의 값.
+   스택 오버플로를 감지하는 데 사용한다. 자세한 내용은 thread.h 상단의 주석을 참고한다. */
 #define THREAD_MAGIC 0xcd6abf4b
 
-/* Random value for basic thread
-   Do not modify this value. */
+/* 기본 스레드 식별에 사용하는 임의의 값.
+   이 값은 수정하지 않는다. */
 #define THREAD_BASIC 0xd42df210
 
-/* List of processes in THREAD_READY state, that is, processes
-   that are ready to run but not actually running. */
+/* THREAD_READY 상태의 스레드 목록.
+   실행할 준비는 되었지만 아직 실제로 실행 중이지 않은 스레드들이 들어간다. */
 static struct list ready_list;
 
-/* Idle thread. */
+/* 유휴 스레드. */
 static struct thread *idle_thread;
 
-/* Initial thread, the thread running init.c:main(). */
+/* 초기 스레드. init.c의 main()을 실행하는 스레드다. */
 static struct thread *initial_thread;
 
-/* Lock used by allocate_tid(). */
+/* allocate_tid()에서 사용하는 락. */
 static struct lock tid_lock;
 
-/* Thread destruction requests */
+/* 제거 대기 중인 스레드 목록. */
 static struct list destruction_req;
 
-// 두 ready list의 원소 중에 어떤 스레드가 앞에 와야 하는지 비교한다.
-// aux는 필요 없으므로 UNUSED로 표시한다. 그저 list api 형식을 맞추기 위해 받는 것. 
-// 같은 priority면 두 스레드의 순서는 상관없으므로 false가 된다. 같은 priority인 경우, 기존 순서가 유지된다.
+// ready_list의 두 원소 중 어떤 스레드가 앞에 와야 하는지 비교한다.
+// aux는 list API 형식을 맞추기 위해 받지만, 우선순위 비교에는 사용하지 않는다.
+// 우선순위가 같으면 false를 반환하여 기존 삽입 순서를 유지한다.
 static bool
 thread_priority_compare (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
     
-	// list_entry 매크로를 사용하여 list_elem에서 thread 구조체로 변환한다.
+	// list_elem을 실제 thread 구조체 포인터로 변환한다.
 	const struct thread *ta = list_entry (a, struct thread, elem);
     const struct thread *tb = list_entry (b, struct thread, elem);
 
-	// 우선 순위가 높은 스레드가 ready_list의 앞에 오도록 한다.
-	// 같은 우선순위일 때는 false가 되어 기존 순서가 유지되어 fifo가 보장된다.
-	// 왜냐면, list_insert_ordered 함수는 비교 함수가 true를 반환하는 경우에만 새로운 요소를 삽입하기 때문이다.
+	// 우선순위가 높은 스레드가 ready_list의 앞쪽에 오도록 한다.
+	// 같은 우선순위에서는 false가 되므로 FIFO 순서가 유지된다.
     return ta->priority > tb->priority;
 }
 
-/* Statistics. */
-static long long idle_ticks;    /* # of timer ticks spent idle. */
-static long long kernel_ticks;  /* # of timer ticks in kernel threads. */
-static long long user_ticks;    /* # of timer ticks in user programs. */
+/* 통계 정보. */
+static long long idle_ticks;    /* 유휴 상태에서 소비한 타이머 틱 수. */
+static long long kernel_ticks;  /* 커널 스레드에서 소비한 타이머 틱 수. */
+static long long user_ticks;    /* 사용자 프로그램에서 소비한 타이머 틱 수. */
 
-/* Scheduling. */
-#define TIME_SLICE 4            /* # of timer ticks to give each thread. */
-static unsigned thread_ticks;   /* # of timer ticks since last yield. */
+/* 스케줄링. */
+#define TIME_SLICE 4            /* 각 스레드에 부여할 타이머 틱 수. */
+static unsigned thread_ticks;   /* 마지막 yield 이후 지난 타이머 틱 수. */
 
-/* If false (default), use round-robin scheduler.
-   If true, use multi-level feedback queue scheduler.
-   Controlled by kernel command-line option "-o mlfqs". */
+/* false이면 기본 라운드 로빈 스케줄러를 사용한다.
+   true이면 다단계 피드백 큐 스케줄러를 사용한다.
+   커널 명령행 옵션 "-o mlfqs"로 제어한다. */
 bool thread_mlfqs;
 
 static void kernel_thread (thread_func *, void *aux);
@@ -79,83 +77,78 @@ static void do_schedule(int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
 
-/* Returns true if T appears to point to a valid thread. */
+/* T가 유효한 스레드를 가리키는 것으로 보이면 true를 반환한다. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
 
-/* Returns the running thread.
- * Read the CPU's stack pointer `rsp', and then round that
- * down to the start of a page.  Since `struct thread' is
- * always at the beginning of a page and the stack pointer is
- * somewhere in the middle, this locates the curent thread. */
+/* 현재 실행 중인 스레드를 반환한다.
+ * CPU의 스택 포인터 `rsp'를 읽은 뒤 페이지 시작 주소로 내림한다.
+ * `struct thread'는 항상 페이지 시작 지점에 있고 스택 포인터는 그 중간 어딘가에 있으므로,
+ * 이 방식으로 현재 스레드를 찾을 수 있다. */
 #define running_thread() ((struct thread *) (pg_round_down (rrsp ())))
 
 
-// Global descriptor table for the thread_start.
-// Because the gdt will be setup after the thread_init, we should
-// setup temporal gdt first.
+// thread_start를 위한 전역 디스크립터 테이블이다.
+// 실제 GDT는 thread_init 이후에 설정되므로 먼저 임시 GDT를 준비한다.
 static uint64_t gdt[3] = { 0, 0x00af9a000000ffff, 0x00cf92000000ffff };
 
-/* Initializes the threading system by transforming the code
-   that's currently running into a thread.  This can't work in
-   general and it is possible in this case only because loader.S
-   was careful to put the bottom of the stack at a page boundary.
+/* 현재 실행 중인 코드를 스레드로 바꾸어 스레딩 시스템을 초기화한다.
+   일반적으로는 불가능하지만, loader.S가 스택의 바닥을 페이지 경계에 맞춰 두었기 때문에
+   이 경우에는 가능하다.
 
-   Also initializes the run queue and the tid lock.
+   run queue와 tid lock도 함께 초기화한다.
 
-   After calling this function, be sure to initialize the page
-   allocator before trying to create any threads with
-   thread_create().
+   이 함수를 호출한 뒤에는 thread_create()로 스레드를 만들기 전에
+   반드시 페이지 할당자를 초기화해야 한다.
 
-   It is not safe to call thread_current() until this function
-   finishes. */
+   이 함수가 끝나기 전에는 thread_current()를 안전하게 호출할 수 없다. */
 void
 thread_init (void) {
 	ASSERT (intr_get_level () == INTR_OFF);
 
-	/* Reload the temporal gdt for the kernel
-	 * This gdt does not include the user context.
-	 * The kernel will rebuild the gdt with user context, in gdt_init (). */
+	/* 커널용 임시 GDT를 다시 적재한다.
+	 * 이 GDT에는 사용자 컨텍스트가 포함되어 있지 않다.
+	 * 커널은 gdt_init()에서 사용자 컨텍스트를 포함한 GDT를 다시 구성한다. */
 	struct desc_ptr gdt_ds = {
 		.size = sizeof (gdt) - 1,
 		.address = (uint64_t) gdt
 	};
 	lgdt (&gdt_ds);
 
-	/* Init the globla thread context */
+	/* 전역 스레드 컨텍스트를 초기화한다. */
 	lock_init (&tid_lock);
 	list_init (&ready_list);
 	list_init (&destruction_req);
 
-	/* Set up a thread structure for the running thread. */
+	/* 현재 실행 중인 스레드의 thread 구조체를 설정한다. */
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
 	initial_thread->status = THREAD_RUNNING;
 	initial_thread->tid = allocate_tid ();
 }
 
-/* Starts preemptive thread scheduling by enabling interrupts.
-   Also creates the idle thread. */
+/* 인터럽트를 활성화하여 선점형 스레드 스케줄링을 시작한다.
+   유휴 스레드도 함께 생성한다. */
 void
 thread_start (void) {
-	/* Create the idle thread. */
+	/* 유휴 스레드를 생성한다. */
 	struct semaphore idle_started;
 	sema_init (&idle_started, 0);
 	thread_create ("idle", PRI_MIN, idle, &idle_started);
 
-	/* Start preemptive thread scheduling. */
+	/* 선점형 스레드 스케줄링을 시작한다. */
 	intr_enable ();
 
-	/* Wait for the idle thread to initialize idle_thread. */
+	/* 유휴 스레드가 idle_thread를 초기화할 때까지 기다린다. */
 	sema_down (&idle_started);
 }
 
-/* Called by the timer interrupt handler at each timer tick.
-   Thus, this function runs in an external interrupt context. */
+/* 매 타이머 틱마다 타이머 인터럽트 핸들러가 호출한다.
+   따라서 이 함수는 외부 인터럽트 컨텍스트에서 실행된다. */
 void
 thread_tick (void) {
 	struct thread *t = thread_current ();
 
-	/* Update statistics. */
+	/* 통계 정보를 갱신한다. */
 	if (t == idle_thread)
 		idle_ticks++;
 #ifdef USERPROG
@@ -165,33 +158,30 @@ thread_tick (void) {
 	else
 		kernel_ticks++;
 
-	/* Enforce preemption. */
+	/* 선점을 강제한다. */
 	if (++thread_ticks >= TIME_SLICE)
 		intr_yield_on_return ();
 }
 
-/* Prints thread statistics. */
+/* 스레드 통계를 출력한다. */
 void
 thread_print_stats (void) {
 	printf ("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
 			idle_ticks, kernel_ticks, user_ticks);
 }
 
-/* Creates a new kernel thread named NAME with the given initial
-   PRIORITY, which executes FUNCTION passing AUX as the argument,
-   and adds it to the ready queue.  Returns the thread identifier
-   for the new thread, or TID_ERROR if creation fails.
+/* NAME이라는 이름의 새 커널 스레드를 주어진 초기 PRIORITY로 생성한다.
+   새 스레드는 AUX를 인자로 FUNCTION을 실행하며 ready queue에 추가된다.
+   성공하면 새 스레드 식별자를 반환하고, 실패하면 TID_ERROR를 반환한다.
 
-   If thread_start() has been called, then the new thread may be
-   scheduled before thread_create() returns.  It could even exit
-   before thread_create() returns.  Contrariwise, the original
-   thread may run for any amount of time before the new thread is
-   scheduled.  Use a semaphore or some other form of
-   synchronization if you need to ensure ordering.
+   thread_start()가 이미 호출되었다면 새 스레드는 thread_create()가 반환되기 전에
+   스케줄될 수 있다. 심지어 thread_create()가 반환되기 전에 종료될 수도 있다.
+   반대로 기존 스레드는 새 스레드가 스케줄되기 전까지 얼마든지 더 실행될 수 있다.
+   실행 순서를 보장해야 한다면 세마포어 같은 동기화 수단을 사용해야 한다.
 
-   The code provided sets the new thread's `priority' member to
-   PRIORITY, but no actual priority scheduling is implemented.
-   Priority scheduling is the goal of Problem 1-3. */
+   제공된 코드는 새 스레드의 `priority' 멤버를 PRIORITY로 설정하지만,
+   실제 우선순위 스케줄링은 구현되어 있지 않다.
+   우선순위 스케줄링은 Problem 1-3의 목표다. */
 tid_t
 thread_create (const char *name, int priority,
 		thread_func *function, void *aux) {
@@ -200,17 +190,17 @@ thread_create (const char *name, int priority,
 
 	ASSERT (function != NULL);
 
-	/* Allocate thread. */
+	/* 스레드를 할당한다. */
 	t = palloc_get_page (PAL_ZERO);
 	if (t == NULL)
 		return TID_ERROR;
 
-	/* Initialize thread. */
+	/* 스레드를 초기화한다. */
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
-	/* Call the kernel_thread if it scheduled.
-	 * Note) rdi is 1st argument, and rsi is 2nd argument. */
+	/* 스케줄되면 kernel_thread를 호출하도록 설정한다.
+	 * 참고로 rdi는 첫 번째 인자이고, rsi는 두 번째 인자다. */
 	t->tf.rip = (uintptr_t) kernel_thread;
 	t->tf.R.rdi = (uint64_t) function;
 	t->tf.R.rsi = (uint64_t) aux;
@@ -220,27 +210,26 @@ thread_create (const char *name, int priority,
 	t->tf.cs = SEL_KCSEG;
 	t->tf.eflags = FLAG_IF;
 
-	/* Add to run queue. */
+	/* run queue에 추가한다. */
 
-	// 더 높은 priority를 가진 스레드가 READY 상태가 되면, 현재 스레드가 yield하여 CPU를 양보하도록 한다.
-	// 이건 보통 인터럽트가 아니기에 thread_yield()를 직접 호출할 수 있다.
+	// 더 높은 priority를 가진 스레드가 READY 상태가 되면 현재 스레드가 CPU를 양보하도록 한다.
+	// 이 지점은 보통 인터럽트 컨텍스트가 아니므로 thread_yield()를 직접 호출할 수 있다.
 	thread_unblock (t);
 
-	// 만약, 새로 생성된 스레드의 우선순위가 현재 동작하고 있는 스레드의 우선순위 보다 높다면,
+	// 새로 생성된 스레드의 우선순위가 현재 실행 중인 스레드보다 높으면 즉시 양보한다.
 	if (t->priority > thread_current ()->priority) {
 		
-		// 현재 동작하고 있는 스레드가 새로 생성된 스레드에게 바로 CPU를 양보하도록 한다.
+		// 현재 스레드가 새 스레드에게 바로 CPU를 넘기도록 한다.
 		thread_yield ();
 	}
 	return tid;
 }
 
-/* Puts the current thread to sleep.  It will not be scheduled
-   again until awoken by thread_unblock().
+/* 현재 스레드를 sleep 상태로 만든다.
+   thread_unblock()으로 깨어나기 전까지 다시 스케줄되지 않는다.
 
-   This function must be called with interrupts turned off.  It
-   is usually a better idea to use one of the synchronization
-   primitives in synch.h. */
+   이 함수는 인터럽트가 꺼진 상태에서 호출해야 한다.
+   일반적으로는 synch.h의 동기화 primitive를 사용하는 편이 더 낫다. */
 void
 thread_block (void) {
 	ASSERT (!intr_context ());
@@ -249,14 +238,13 @@ thread_block (void) {
 	schedule ();
 }
 
-/* Transitions a blocked thread T to the ready-to-run state.
-   This is an error if T is not blocked.  (Use thread_yield() to
-   make the running thread ready.)
+/* BLOCKED 상태의 스레드 T를 ready-to-run 상태로 전환한다.
+   T가 BLOCKED 상태가 아니면 오류다. 실행 중인 스레드를 READY 상태로 만들려면
+   thread_yield()를 사용한다.
 
-   This function does not preempt the running thread.  This can
-   be important: if the caller had disabled interrupts itself,
-   it may expect that it can atomically unblock a thread and
-   update other data. */
+   이 함수는 현재 실행 중인 스레드를 선점하지 않는다.
+   호출자가 직접 인터럽트를 꺼 두었다면, 스레드를 원자적으로 깨우고
+   다른 데이터까지 갱신할 수 있다고 기대할 수 있기 때문이다. */
 void
 thread_unblock (struct thread *t) {
 	enum intr_level old_level;
@@ -266,45 +254,44 @@ thread_unblock (struct thread *t) {
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
 	
-	// ready_list를 항상 우선순위 내림차순으로 정렬되도록 한다.
-	// ready_list에 thread t를 넣어야 하는데, thread_priority_compare 함수를 통해 정렬해서 넣는다.
+	// ready_list를 항상 우선순위 내림차순으로 정렬되도록 유지한다.
+	// thread_priority_compare()를 기준으로 스레드 t를 알맞은 위치에 삽입한다.
 	list_insert_ordered (&ready_list, &t->elem, thread_priority_compare, NULL); 
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
 
-/* Returns the name of the running thread. */
+/* 현재 실행 중인 스레드의 이름을 반환한다. */
 const char *
 thread_name (void) {
 	return thread_current ()->name;
 }
 
-/* Returns the running thread.
-   This is running_thread() plus a couple of sanity checks.
-   See the big comment at the top of thread.h for details. */
+/* 현재 실행 중인 스레드를 반환한다.
+   running_thread()에 몇 가지 sanity check를 더한 함수다.
+   자세한 내용은 thread.h 상단의 주석을 참고한다. */
 struct thread *
 thread_current (void) {
 	struct thread *t = running_thread ();
 
-	/* Make sure T is really a thread.
-	   If either of these assertions fire, then your thread may
-	   have overflowed its stack.  Each thread has less than 4 kB
-	   of stack, so a few big automatic arrays or moderate
-	   recursion can cause stack overflow. */
+	/* T가 실제 스레드인지 확인한다.
+	   이 ASSERT 중 하나라도 실패한다면 스레드의 스택이 오버플로되었을 수 있다.
+	   각 스레드의 스택은 4KB보다 작으므로 큰 자동 배열 몇 개나
+	   적당한 수준의 재귀만으로도 스택 오버플로가 발생할 수 있다. */
 	ASSERT (is_thread (t));
 	ASSERT (t->status == THREAD_RUNNING);
 
 	return t;
 }
 
-/* Returns the running thread's tid. */
+/* 현재 실행 중인 스레드의 tid를 반환한다. */
 tid_t
 thread_tid (void) {
 	return thread_current ()->tid;
 }
 
-/* Deschedules the current thread and destroys it.  Never
-   returns to the caller. */
+/* 현재 스레드를 스케줄 대상에서 제외하고 제거한다.
+   호출자에게 절대 반환하지 않는다. */
 void
 thread_exit (void) {
 	ASSERT (!intr_context ());
@@ -313,105 +300,106 @@ thread_exit (void) {
 	process_exit ();
 #endif
 
-	/* Just set our status to dying and schedule another process.
-	   We will be destroyed during the call to schedule_tail(). */
+	/* 상태만 dying으로 바꾸고 다른 프로세스를 스케줄한다.
+	   실제 제거는 schedule_tail() 호출 중에 이루어진다. */
 	intr_disable ();
 	do_schedule (THREAD_DYING);
 	NOT_REACHED ();
 }
 
-/* Yields the CPU.  The current thread is not put to sleep and
-   may be scheduled again immediately at the scheduler's whim. */
+/* CPU를 양보한다. 현재 스레드는 sleep 상태가 아니므로,
+   스케줄러의 판단에 따라 곧바로 다시 스케줄될 수도 있다. */
 void
 thread_yield (void) {
 	struct thread *curr = thread_current ();
 	enum intr_level old_level;
 
-	// 인터럽트 핸들러 안에서는 일반적인 yield를 호출하면 안 된다. 대신 intr_yield_on_return()를 호출해야 한다.
+	// 인터럽트 핸들러 안에서는 일반적인 yield를 호출하면 안 된다.
+	// 이 경우에는 intr_yield_on_return()을 사용해야 한다.
 	ASSERT (!intr_context ());
 
-	// 현재 스레드를 ready_list에 넣는 동안 인터럽트가 발생하면 안 된다. 인터럽트가 발생하면 스케줄링이 일어나서 ready_list가 변경될 수 있기 때문이다.
-	// 그래서 꺼준다.
+	// 현재 스레드를 ready_list에 넣는 동안 인터럽트가 끼어들지 않도록 막는다.
+	// 인터럽트가 끼어들면 스케줄링이 발생해 ready_list가 동시에 바뀔 수 있다.
 	old_level = intr_disable ();
 	
-	// idle thread는 ready_list에 넣지 않고, ready thread 가 하나도 없을 때에만 실행한다. cpu가 노는걸 방지하기 위해서이다.
-	// 여기서는 현재 current thread가 idle thread가 아니라면, ready_list에 다시 넣어준다.
+	// idle_thread는 ready_list에 넣지 않는다.
+	// 실행 가능한 일반 스레드가 하나도 없을 때만 idle_thread를 실행한다.
 	if (curr != idle_thread) { 
-		// 다시 ready 상태가 되는 순간에도, 우선순위 순서를 유지해야 한다.
-	// 두 스레드를 비교하는 함수를 통해, ready_list에 current thread를 우선순위에 맞게 삽입한다.
+		// 다시 READY 상태가 되는 순간에도 우선순위 순서를 유지해야 한다.
+		// 현재 스레드를 ready_list의 우선순위에 맞는 위치에 삽입한다.
 		list_insert_ordered (&ready_list, &curr->elem, thread_priority_compare, NULL);
 	}
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
 }
 
-/* Sets the current thread's priority to NEW_PRIORITY. */
+/* 현재 스레드의 priority를 NEW_PRIORITY로 설정한다. */
 
-// 현재 스레드가 priority를 낮췄을 때, ready 상태의 더 높은 스레드에게 바로 cpu를 양보하도록 함.
+// 현재 스레드가 priority를 낮췄을 때,
+// READY 상태의 더 높은 우선순위 스레드에게 바로 CPU를 양보하도록 한다.
 void
 thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
+	// 중복 처리
+	// thread_current ()->priority = new_priority;
 
 	struct thread *curr = thread_current ();
 
 	// 현재 스레드의 우선순위를 새 값으로 갱신한다.
 	curr->priority = new_priority;
 
-	// ready list는 이미 정렬 되어있다.
-	// 그래서 ready list의 맨 앞 원소만 보면, 현재 ready 상태인 스레드 중에 가장 높은 우선순위인 스레드를 알 수 있다.
+	// ready_list는 이미 우선순위 순서로 정렬되어 있다.
+	// 따라서 맨 앞 원소가 READY 상태 스레드 중 가장 높은 우선순위를 가진다.
 	if (!list_empty (&ready_list)) {
 		struct thread *front = list_entry (list_front (&ready_list), struct thread, elem);
 
-		// 그런데, 만약에 ready list 맨 앞 원소의 우선순위가 현재 스레드의 우선순위보다 높다면, 
+		// 현재 스레드보다 더 높은 우선순위의 READY 스레드가 있으면 CPU를 양보한다.
 		if (front->priority > curr->priority) {
-			// 현재 스레드는 yield하여 CPU를 양보하도록 한다.
 			thread_yield ();
 		}
 	}	
 }
 
-/* Returns the current thread's priority. */
+/* 현재 스레드의 priority를 반환한다. */
 int
 thread_get_priority (void) {
 	return thread_current ()->priority;
 }
 
-/* Sets the current thread's nice value to NICE. */
+/* 현재 스레드의 nice 값을 NICE로 설정한다. */
 void
 thread_set_nice (int nice UNUSED) {
-	/* TODO: Your implementation goes here */
+	/* TODO: 여기에 구현을 추가한다. */
 }
 
-/* Returns the current thread's nice value. */
+/* 현재 스레드의 nice 값을 반환한다. */
 int
 thread_get_nice (void) {
-	/* TODO: Your implementation goes here */
+	/* TODO: 여기에 구현을 추가한다. */
 	return 0;
 }
 
-/* Returns 100 times the system load average. */
+/* 시스템 load average의 100배 값을 반환한다. */
 int
 thread_get_load_avg (void) {
-	/* TODO: Your implementation goes here */
+	/* TODO: 여기에 구현을 추가한다. */
 	return 0;
 }
 
-/* Returns 100 times the current thread's recent_cpu value. */
+/* 현재 스레드의 recent_cpu 값의 100배를 반환한다. */
 int
 thread_get_recent_cpu (void) {
-	/* TODO: Your implementation goes here */
+	/* TODO: 여기에 구현을 추가한다. */
 	return 0;
 }
 
-/* Idle thread.  Executes when no other thread is ready to run.
+/* 유휴 스레드.
+   실행 가능한 다른 스레드가 없을 때 실행된다.
 
-   The idle thread is initially put on the ready list by
-   thread_start().  It will be scheduled once initially, at which
-   point it initializes idle_thread, "up"s the semaphore passed
-   to it to enable thread_start() to continue, and immediately
-   blocks.  After that, the idle thread never appears in the
-   ready list.  It is returned by next_thread_to_run() as a
-   special case when the ready list is empty. */
+   유휴 스레드는 처음에 thread_start()에 의해 ready list에 들어간다.
+   처음 한 번 스케줄되면 idle_thread를 초기화하고, 전달받은 세마포어를 up해서
+   thread_start()가 계속 진행할 수 있게 한 뒤 즉시 block된다.
+   그 이후 유휴 스레드는 ready list에 다시 나타나지 않는다.
+   ready list가 비어 있을 때 next_thread_to_run()이 특수한 경우로 이 스레드를 반환한다. */
 static void
 idle (void *idle_started_ UNUSED) {
 	struct semaphore *idle_started = idle_started_;
@@ -420,39 +408,35 @@ idle (void *idle_started_ UNUSED) {
 	sema_up (idle_started);
 
 	for (;;) {
-		/* Let someone else run. */
+		/* 다른 스레드가 실행될 수 있게 한다. */
 		intr_disable ();
 		thread_block ();
 
-		/* Re-enable interrupts and wait for the next one.
+		/* 인터럽트를 다시 켜고 다음 인터럽트를 기다린다.
 
-		   The `sti' instruction disables interrupts until the
-		   completion of the next instruction, so these two
-		   instructions are executed atomically.  This atomicity is
-		   important; otherwise, an interrupt could be handled
-		   between re-enabling interrupts and waiting for the next
-		   one to occur, wasting as much as one clock tick worth of
-		   time.
+		   `sti' 명령은 다음 명령이 끝날 때까지 인터럽트를 비활성화하므로,
+		   이 두 명령은 원자적으로 실행된다. 이 원자성은 중요하다.
+		   그렇지 않으면 인터럽트를 다시 켠 뒤 다음 인터럽트를 기다리기 전에
+		   인터럽트가 처리되어 최대 한 clock tick만큼 시간을 낭비할 수 있다.
 
-		   See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
-		   7.11.1 "HLT Instruction". */
+		   자세한 내용은 [IA32-v2a] "HLT", [IA32-v2b] "STI",
+		   [IA32-v3a] 7.11.1 "HLT Instruction"을 참고한다. */
 		asm volatile ("sti; hlt" : : : "memory");
 	}
 }
 
-/* Function used as the basis for a kernel thread. */
+/* 커널 스레드의 시작점으로 사용하는 함수. */
 static void
 kernel_thread (thread_func *function, void *aux) {
 	ASSERT (function != NULL);
 
-	intr_enable ();       /* The scheduler runs with interrupts off. */
-	function (aux);       /* Execute the thread function. */
-	thread_exit ();       /* If function() returns, kill the thread. */
+	intr_enable ();       /* 스케줄러는 인터럽트가 꺼진 상태에서 실행된다. */
+	function (aux);       /* 스레드 함수를 실행한다. */
+	thread_exit ();       /* function()이 반환되면 스레드를 종료한다. */
 }
 
 
-/* Does basic initialization of T as a blocked thread named
-   NAME. */
+/* T를 NAME이라는 이름의 BLOCKED 상태 스레드로 기본 초기화한다. */
 static void
 init_thread (struct thread *t, const char *name, int priority) {
 	ASSERT (t != NULL);
@@ -467,11 +451,10 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->magic = THREAD_MAGIC;
 }
 
-/* Chooses and returns the next thread to be scheduled.  Should
-   return a thread from the run queue, unless the run queue is
-   empty.  (If the running thread can continue running, then it
-   will be in the run queue.)  If the run queue is empty, return
-   idle_thread. */
+/* 다음에 스케줄할 스레드를 선택해 반환한다.
+   run queue가 비어 있지 않으면 그 안의 스레드를 반환해야 한다.
+   현재 실행 중인 스레드가 계속 실행될 수 있다면 그 스레드도 run queue 안에 있다.
+   run queue가 비어 있으면 idle_thread를 반환한다. */
 static struct thread *
 next_thread_to_run (void) {
 	if (list_empty (&ready_list))
@@ -480,7 +463,7 @@ next_thread_to_run (void) {
 		return list_entry (list_pop_front (&ready_list), struct thread, elem);
 }
 
-/* Use iretq to launch the thread */
+/* iretq를 사용해 스레드를 시작한다. */
 void
 do_iret (struct intr_frame *tf) {
 	__asm __volatile(
@@ -508,33 +491,30 @@ do_iret (struct intr_frame *tf) {
 			: : "g" ((uint64_t) tf) : "memory");
 }
 
-/* Switching the thread by activating the new thread's page
-   tables, and, if the previous thread is dying, destroying it.
+/* 새 스레드의 페이지 테이블을 활성화해 스레드를 전환하고,
+   이전 스레드가 dying 상태라면 제거한다.
 
-   At this function's invocation, we just switched from thread
-   PREV, the new thread is already running, and interrupts are
-   still disabled.
+   이 함수가 호출되는 시점에는 이전 스레드에서 막 전환된 직후이며,
+   새 스레드는 이미 실행 중이고 인터럽트는 여전히 비활성화되어 있다.
 
-   It's not safe to call printf() until the thread switch is
-   complete.  In practice that means that printf()s should be
-   added at the end of the function. */
+   스레드 전환이 끝나기 전까지 printf()를 호출하는 것은 안전하지 않다.
+   실제로는 함수 끝부분에만 printf()를 추가해야 한다는 뜻이다. */
 static void
 thread_launch (struct thread *th) {
 	uint64_t tf_cur = (uint64_t) &running_thread ()->tf;
 	uint64_t tf = (uint64_t) &th->tf;
 	ASSERT (intr_get_level () == INTR_OFF);
 
-	/* The main switching logic.
-	 * We first restore the whole execution context into the intr_frame
-	 * and then switching to the next thread by calling do_iret.
-	 * Note that, we SHOULD NOT use any stack from here
-	 * until switching is done. */
+	/* 핵심 전환 로직이다.
+	 * 먼저 전체 실행 컨텍스트를 intr_frame에 복구한 뒤,
+	 * do_iret를 호출해 다음 스레드로 전환한다.
+	 * 여기서부터 전환이 끝날 때까지는 어떤 스택도 사용하면 안 된다. */
 	__asm __volatile (
-			/* Store registers that will be used. */
+			/* 사용할 레지스터를 저장한다. */
 			"push %%rax\n"
 			"push %%rbx\n"
 			"push %%rcx\n"
-			/* Fetch input once */
+			/* 입력값을 한 번만 읽는다. */
 			"movq %0, %%rax\n"
 			"movq %1, %%rcx\n"
 			"movq %%r15, 0(%%rax)\n"
@@ -549,17 +529,17 @@ thread_launch (struct thread *th) {
 			"movq %%rdi, 72(%%rax)\n"
 			"movq %%rbp, 80(%%rax)\n"
 			"movq %%rdx, 88(%%rax)\n"
-			"pop %%rbx\n"              // Saved rcx
+			"pop %%rbx\n"              // 저장해 둔 rcx
 			"movq %%rbx, 96(%%rax)\n"
-			"pop %%rbx\n"              // Saved rbx
+			"pop %%rbx\n"              // 저장해 둔 rbx
 			"movq %%rbx, 104(%%rax)\n"
-			"pop %%rbx\n"              // Saved rax
+			"pop %%rbx\n"              // 저장해 둔 rax
 			"movq %%rbx, 112(%%rax)\n"
 			"addq $120, %%rax\n"
 			"movw %%es, (%%rax)\n"
 			"movw %%ds, 8(%%rax)\n"
 			"addq $32, %%rax\n"
-			"call __next\n"         // read the current rip.
+			"call __next\n"         // 현재 rip를 읽는다.
 			"__next:\n"
 			"pop %%rbx\n"
 			"addq $(out_iret -  __next), %%rbx\n"
@@ -577,10 +557,10 @@ thread_launch (struct thread *th) {
 			);
 }
 
-/* Schedules a new process. At entry, interrupts must be off.
- * This function modify current thread's status to status and then
- * finds another thread to run and switches to it.
- * It's not safe to call printf() in the schedule(). */
+/* 새 프로세스를 스케줄한다. 진입 시점에는 인터럽트가 꺼져 있어야 한다.
+ * 이 함수는 현재 스레드의 상태를 status로 바꾼 뒤,
+ * 실행할 다른 스레드를 찾아 전환한다.
+ * schedule() 안에서 printf()를 호출하는 것은 안전하지 않다. */
 static void
 do_schedule(int status) {
 	ASSERT (intr_get_level () == INTR_OFF);
@@ -602,37 +582,33 @@ schedule (void) {
 	ASSERT (intr_get_level () == INTR_OFF);
 	ASSERT (curr->status != THREAD_RUNNING);
 	ASSERT (is_thread (next));
-	/* Mark us as running. */
+	/* 새 스레드를 실행 중 상태로 표시한다. */
 	next->status = THREAD_RUNNING;
 
-	/* Start new time slice. */
+	/* 새 time slice를 시작한다. */
 	thread_ticks = 0;
 
 #ifdef USERPROG
-	/* Activate the new address space. */
+	/* 새 주소 공간을 활성화한다. */
 	process_activate (next);
 #endif
 
 	if (curr != next) {
-		/* If the thread we switched from is dying, destroy its struct
-		   thread. This must happen late so that thread_exit() doesn't
-		   pull out the rug under itself.
-		   We just queuing the page free reqeust here because the page is
-		   currently used by the stack.
-		   The real destruction logic will be called at the beginning of the
-		   schedule(). */
+		/* 방금 전환되어 나온 스레드가 dying 상태라면 그 struct thread를 제거한다.
+		   thread_exit()가 자기 발판을 스스로 걷어차지 않게 하려면 이 작업은 늦게 이루어져야 한다.
+		   해당 페이지는 현재 스택이 사용 중이므로 여기서는 page free 요청만 큐에 넣는다.
+		   실제 제거 로직은 schedule() 시작 부분에서 호출된다. */
 		if (curr && curr->status == THREAD_DYING && curr != initial_thread) {
 			ASSERT (curr != next);
 			list_push_back (&destruction_req, &curr->elem);
 		}
 
-		/* Before switching the thread, we first save the information
-		 * of current running. */
+		/* 스레드를 전환하기 전에 현재 실행 중인 스레드의 정보를 먼저 저장한다. */
 		thread_launch (next);
 	}
 }
 
-/* Returns a tid to use for a new thread. */
+/* 새 스레드에 사용할 tid를 반환한다. */
 static tid_t
 allocate_tid (void) {
 	static tid_t next_tid = 1;

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -15,43 +15,59 @@
 #include "userprog/process.h"
 #endif
 
-/* struct thread의 `magic' 멤버에 사용하는 임의 값.
-   스택 오버플로를 감지하는 데 사용된다. 자세한 내용은
-   thread.h 상단의 큰 주석을 참고하라. */
+/* Random value for struct thread's `magic' member.
+   Used to detect stack overflow.  See the big comment at the top
+   of thread.h for details. */
 #define THREAD_MAGIC 0xcd6abf4b
 
-/* 기본 thread를 위한 임의 값
-   이 값은 수정하지 말 것. */
+/* Random value for basic thread
+   Do not modify this value. */
 #define THREAD_BASIC 0xd42df210
 
-/* THREAD_READY 상태의 프로세스 목록, 즉 실행할 준비는 되었지만
-   실제로 실행 중은 아닌 프로세스들이다. */
+/* List of processes in THREAD_READY state, that is, processes
+   that are ready to run but not actually running. */
 static struct list ready_list;
 
-/* idle thread(유휴 스레드). */
+/* Idle thread. */
 static struct thread *idle_thread;
 
-/* 초기 thread, 즉 init.c:main()을 실행하는 thread. */
+/* Initial thread, the thread running init.c:main(). */
 static struct thread *initial_thread;
 
-/* allocate_tid()에서 사용하는 lock. */
+/* Lock used by allocate_tid(). */
 static struct lock tid_lock;
 
-/* thread 파기 요청 */
+/* Thread destruction requests */
 static struct list destruction_req;
 
-/* 통계. */
-static long long idle_ticks;    /* idle 상태에서 소비한 timer tick 수. */
-static long long kernel_ticks;  /* kernel thread에서 소비한 timer tick 수. */
-static long long user_ticks;    /* user program에서 소비한 timer tick 수. */
+// 두 ready list의 원소 중에 어떤 스레드가 앞에 와야 하는지 비교한다.
+// aux는 필요 없으므로 UNUSED로 표시한다. 그저 list api 형식을 맞추기 위해 받는 것. 
+// 같은 priority면 두 스레드의 순서는 상관없으므로 false가 된다. 같은 priority인 경우, 기존 순서가 유지된다.
+static bool
+thread_priority_compare (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+    
+	// list_entry 매크로를 사용하여 list_elem에서 thread 구조체로 변환한다.
+	const struct thread *ta = list_entry (a, struct thread, elem);
+    const struct thread *tb = list_entry (b, struct thread, elem);
 
-/* 스케줄링. */
-#define TIME_SLICE 4            /* 각 thread에 할당할 timer tick 수. */
-static unsigned thread_ticks;   /* 마지막 yield 이후의 timer tick 수. */
+	// 우선 순위가 높은 스레드가 ready_list의 앞에 오도록 한다.
+	// 같은 우선순위일 때는 false가 되어 기존 순서가 유지되어 fifo가 보장된다.
+	// 왜냐면, list_insert_ordered 함수는 비교 함수가 true를 반환하는 경우에만 새로운 요소를 삽입하기 때문이다.
+    return ta->priority > tb->priority;
+}
 
-/* false(기본값)면 round-robin scheduler를 사용한다.
-   true면 multi-level feedback queue scheduler를 사용한다.
-   kernel command-line option "-o mlfqs"로 제어한다. */
+/* Statistics. */
+static long long idle_ticks;    /* # of timer ticks spent idle. */
+static long long kernel_ticks;  /* # of timer ticks in kernel threads. */
+static long long user_ticks;    /* # of timer ticks in user programs. */
+
+/* Scheduling. */
+#define TIME_SLICE 4            /* # of timer ticks to give each thread. */
+static unsigned thread_ticks;   /* # of timer ticks since last yield. */
+
+/* If false (default), use round-robin scheduler.
+   If true, use multi-level feedback queue scheduler.
+   Controlled by kernel command-line option "-o mlfqs". */
 bool thread_mlfqs;
 
 static void kernel_thread (thread_func *, void *aux);
@@ -63,77 +79,83 @@ static void do_schedule(int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
 
-/* T가 유효한 thread를 가리키는 것처럼 보이면 true를 반환한다. */
+/* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
 
-/* 현재 실행 중인 thread를 반환한다.
- * CPU의 stack pointer `rsp'를 읽은 뒤 페이지 시작 주소로
- * 내림한다. `struct thread'는 항상 페이지 시작에 있고
- * stack pointer는 그 중간 어딘가에 있으므로, 이렇게 하면
- * 현재 thread를 찾을 수 있다. */
+/* Returns the running thread.
+ * Read the CPU's stack pointer `rsp', and then round that
+ * down to the start of a page.  Since `struct thread' is
+ * always at the beginning of a page and the stack pointer is
+ * somewhere in the middle, this locates the curent thread. */
 #define running_thread() ((struct thread *) (pg_round_down (rrsp ())))
 
 
-// thread_start를 위한 Global Descriptor Table.
-// gdt는 thread_init 이후에 설정되므로,
-// 먼저 임시 gdt를 설정해야 한다.
+// Global descriptor table for the thread_start.
+// Because the gdt will be setup after the thread_init, we should
+// setup temporal gdt first.
 static uint64_t gdt[3] = { 0, 0x00af9a000000ffff, 0x00cf92000000ffff };
 
-/* 현재 실행 중인 코드를 thread로 변환하여 threading system을
-   초기화한다. 일반적으로는 이런 방식이 성립하지 않지만, 이 경우에는
-   loader.S가 stack의 바닥을 페이지 경계에 맞춰 두었기 때문에 가능하다.
-   또한 run queue와 tid lock도 초기화한다.
-   이 함수를 호출한 뒤에는 thread_create()로 thread를 만들기 전에
-   반드시 page allocator를 초기화해야 한다.
-   이 함수가 끝나기 전까지는 thread_current()를 호출하는 것이 안전하지 않다. */
+/* Initializes the threading system by transforming the code
+   that's currently running into a thread.  This can't work in
+   general and it is possible in this case only because loader.S
+   was careful to put the bottom of the stack at a page boundary.
+
+   Also initializes the run queue and the tid lock.
+
+   After calling this function, be sure to initialize the page
+   allocator before trying to create any threads with
+   thread_create().
+
+   It is not safe to call thread_current() until this function
+   finishes. */
 void
 thread_init (void) {
 	ASSERT (intr_get_level () == INTR_OFF);
 
-	/* kernel용 임시 gdt를 다시 적재한다.
-	 * 이 gdt에는 user context가 포함되어 있지 않다.
-	 * kernel은 gdt_init()에서 user context를 포함해 gdt를 다시 구성한다. */
+	/* Reload the temporal gdt for the kernel
+	 * This gdt does not include the user context.
+	 * The kernel will rebuild the gdt with user context, in gdt_init (). */
 	struct desc_ptr gdt_ds = {
 		.size = sizeof (gdt) - 1,
 		.address = (uint64_t) gdt
 	};
 	lgdt (&gdt_ds);
 
-	/* 전역 thread context를 초기화한다. */
+	/* Init the globla thread context */
 	lock_init (&tid_lock);
 	list_init (&ready_list);
 	list_init (&destruction_req);
 
-	/* 현재 실행 중인 thread를 위한 thread 구조체를 설정한다. */
+	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
 	initial_thread->status = THREAD_RUNNING;
 	initial_thread->tid = allocate_tid ();
 }
 
-/* interrupt를 활성화하여 선점형 thread scheduling을 시작한다.
-   또한 idle thread를 생성한다. */
+/* Starts preemptive thread scheduling by enabling interrupts.
+   Also creates the idle thread. */
 void
 thread_start (void) {
-	/* idle thread를 생성한다. */
+	/* Create the idle thread. */
 	struct semaphore idle_started;
 	sema_init (&idle_started, 0);
 	thread_create ("idle", PRI_MIN, idle, &idle_started);
 
-	/* 선점형 thread scheduling을 시작한다. */
+	/* Start preemptive thread scheduling. */
 	intr_enable ();
 
-	/* idle thread가 idle_thread를 초기화할 때까지 기다린다. */
+	/* Wait for the idle thread to initialize idle_thread. */
 	sema_down (&idle_started);
 }
 
-/* 매 timer tick마다 timer interrupt handler가 호출한다.
-   따라서 이 함수는 external interrupt context에서 실행된다. */
+/* Called by the timer interrupt handler at each timer tick.
+   Thus, this function runs in an external interrupt context. */
 void
 thread_tick (void) {
 	struct thread *t = thread_current ();
 
-	/* 통계를 갱신한다. */
+	/* Update statistics. */
 	if (t == idle_thread)
 		idle_ticks++;
 #ifdef USERPROG
@@ -143,29 +165,33 @@ thread_tick (void) {
 	else
 		kernel_ticks++;
 
-	/* 선점을 강제한다. */
+	/* Enforce preemption. */
 	if (++thread_ticks >= TIME_SLICE)
 		intr_yield_on_return ();
 }
 
-/* thread 통계를 출력한다. */
+/* Prints thread statistics. */
 void
 thread_print_stats (void) {
 	printf ("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
 			idle_ticks, kernel_ticks, user_ticks);
 }
 
-/* NAME이라는 새 kernel thread를 주어진 초기 PRIORITY로 생성한다.
-   이 thread는 AUX를 인자로 FUNCTION을 실행하며 ready queue에 추가된다.
-   성공하면 새 thread의 식별자를, 실패하면 TID_ERROR를 반환한다.
-   thread_start()가 이미 호출되었다면, 새 thread는
-   thread_create()가 반환되기 전에 스케줄될 수 있다. 심지어
-   thread_create()가 반환되기 전에 종료할 수도 있다. 반대로 원래
-   thread는 새 thread가 스케줄되기 전까지 얼마든지 더 실행될 수 있다.
-   순서를 보장해야 한다면 semaphore나 다른 synchronization 수단을 사용하라.
-   제공된 코드는 새 thread의 `priority' 멤버를 PRIORITY로 설정하지만,
-   실제 priority scheduling은 구현되어 있지 않다.
-   priority scheduling은 Problem 1-3의 목표다. */
+/* Creates a new kernel thread named NAME with the given initial
+   PRIORITY, which executes FUNCTION passing AUX as the argument,
+   and adds it to the ready queue.  Returns the thread identifier
+   for the new thread, or TID_ERROR if creation fails.
+
+   If thread_start() has been called, then the new thread may be
+   scheduled before thread_create() returns.  It could even exit
+   before thread_create() returns.  Contrariwise, the original
+   thread may run for any amount of time before the new thread is
+   scheduled.  Use a semaphore or some other form of
+   synchronization if you need to ensure ordering.
+
+   The code provided sets the new thread's `priority' member to
+   PRIORITY, but no actual priority scheduling is implemented.
+   Priority scheduling is the goal of Problem 1-3. */
 tid_t
 thread_create (const char *name, int priority,
 		thread_func *function, void *aux) {
@@ -174,17 +200,17 @@ thread_create (const char *name, int priority,
 
 	ASSERT (function != NULL);
 
-	/* thread를 할당한다. */
+	/* Allocate thread. */
 	t = palloc_get_page (PAL_ZERO);
 	if (t == NULL)
 		return TID_ERROR;
 
-	/* thread를 초기화한다. */
+	/* Initialize thread. */
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
-	/* 스케줄되면 kernel_thread를 호출하게 한다.
-	 * 참고) rdi는 첫 번째 인자이고, rsi는 두 번째 인자다. */
+	/* Call the kernel_thread if it scheduled.
+	 * Note) rdi is 1st argument, and rsi is 2nd argument. */
 	t->tf.rip = (uintptr_t) kernel_thread;
 	t->tf.R.rdi = (uint64_t) function;
 	t->tf.R.rsi = (uint64_t) aux;
@@ -194,16 +220,27 @@ thread_create (const char *name, int priority,
 	t->tf.cs = SEL_KCSEG;
 	t->tf.eflags = FLAG_IF;
 
-	/* run queue에 추가한다. */
+	/* Add to run queue. */
+
+	// 더 높은 priority를 가진 스레드가 READY 상태가 되면, 현재 스레드가 yield하여 CPU를 양보하도록 한다.
+	// 이건 보통 인터럽트가 아니기에 thread_yield()를 직접 호출할 수 있다.
 	thread_unblock (t);
 
+	// 만약, 새로 생성된 스레드의 우선순위가 현재 동작하고 있는 스레드의 우선순위 보다 높다면,
+	if (t->priority > thread_current ()->priority) {
+		
+		// 현재 동작하고 있는 스레드가 새로 생성된 스레드에게 바로 CPU를 양보하도록 한다.
+		thread_yield ();
+	}
 	return tid;
 }
 
-/* 현재 thread를 sleep 상태로 만든다. thread_unblock()로 깨우기 전까지는
-   다시 스케줄되지 않는다.
-   이 함수는 interrupt를 끈 상태에서 호출해야 한다. 보통은
-   synch.h의 synchronization primitive를 사용하는 편이 더 낫다. */
+/* Puts the current thread to sleep.  It will not be scheduled
+   again until awoken by thread_unblock().
+
+   This function must be called with interrupts turned off.  It
+   is usually a better idea to use one of the synchronization
+   primitives in synch.h. */
 void
 thread_block (void) {
 	ASSERT (!intr_context ());
@@ -212,12 +249,14 @@ thread_block (void) {
 	schedule ();
 }
 
-/* blocked 상태의 thread T를 ready-to-run 상태로 전이시킨다.
-   T가 blocked 상태가 아니면 오류다. (실행 중인 thread를 ready 상태로
-   만들려면 thread_yield()를 사용하라.)
-   이 함수는 현재 실행 중인 thread를 선점하지 않는다. 이는 중요할 수 있다.
-   호출자가 직접 interrupt를 꺼 두었다면, thread 하나를 원자적으로
-   unblock하고 다른 데이터까지 갱신할 수 있다고 기대할 수 있기 때문이다. */
+/* Transitions a blocked thread T to the ready-to-run state.
+   This is an error if T is not blocked.  (Use thread_yield() to
+   make the running thread ready.)
+
+   This function does not preempt the running thread.  This can
+   be important: if the caller had disabled interrupts itself,
+   it may expect that it can atomically unblock a thread and
+   update other data. */
 void
 thread_unblock (struct thread *t) {
 	enum intr_level old_level;
@@ -226,42 +265,46 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	
+	// ready_list를 항상 우선순위 내림차순으로 정렬되도록 한다.
+	// ready_list에 thread t를 넣어야 하는데, thread_priority_compare 함수를 통해 정렬해서 넣는다.
+	list_insert_ordered (&ready_list, &t->elem, thread_priority_compare, NULL); 
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
 
-/* 현재 실행 중인 thread의 이름을 반환한다. */
+/* Returns the name of the running thread. */
 const char *
 thread_name (void) {
 	return thread_current ()->name;
 }
 
-/* 현재 실행 중인 thread를 반환한다.
-   running_thread()에 몇 가지 sanity check를 더한 것이다.
-   자세한 내용은 thread.h 상단의 큰 주석을 참고하라. */
+/* Returns the running thread.
+   This is running_thread() plus a couple of sanity checks.
+   See the big comment at the top of thread.h for details. */
 struct thread *
 thread_current (void) {
 	struct thread *t = running_thread ();
 
-	/* T가 실제로 thread인지 확인한다.
-	   이 assert 중 하나라도 터진다면 thread의 stack이 overflow되었을
-	   수 있다. 각 thread의 stack은 4 kB보다 작으므로, 큰 자동 배열 몇 개나
-	   적당한 수준의 재귀만으로도 stack overflow가 발생할 수 있다. */
+	/* Make sure T is really a thread.
+	   If either of these assertions fire, then your thread may
+	   have overflowed its stack.  Each thread has less than 4 kB
+	   of stack, so a few big automatic arrays or moderate
+	   recursion can cause stack overflow. */
 	ASSERT (is_thread (t));
 	ASSERT (t->status == THREAD_RUNNING);
 
 	return t;
 }
 
-/* 현재 실행 중인 thread의 tid를 반환한다. */
+/* Returns the running thread's tid. */
 tid_t
 thread_tid (void) {
 	return thread_current ()->tid;
 }
 
-/* 현재 thread를 스케줄 대상에서 제외하고 파기한다.
-   호출자에게 절대 돌아오지 않는다. */
+/* Deschedules the current thread and destroys it.  Never
+   returns to the caller. */
 void
 thread_exit (void) {
 	ASSERT (!intr_context ());
@@ -270,75 +313,105 @@ thread_exit (void) {
 	process_exit ();
 #endif
 
-	/* 상태만 dying으로 바꾸고 다른 프로세스를 스케줄한다.
-	   실제 파기는 schedule_tail() 호출 중에 이루어진다. */
+	/* Just set our status to dying and schedule another process.
+	   We will be destroyed during the call to schedule_tail(). */
 	intr_disable ();
 	do_schedule (THREAD_DYING);
 	NOT_REACHED ();
 }
 
-/* CPU를 양보한다. 현재 thread는 sleep 상태로 들어가지 않으며,
-   scheduler 판단에 따라 곧바로 다시 스케줄될 수도 있다. */
+/* Yields the CPU.  The current thread is not put to sleep and
+   may be scheduled again immediately at the scheduler's whim. */
 void
 thread_yield (void) {
 	struct thread *curr = thread_current ();
 	enum intr_level old_level;
 
+	// 인터럽트 핸들러 안에서는 일반적인 yield를 호출하면 안 된다. 대신 intr_yield_on_return()를 호출해야 한다.
 	ASSERT (!intr_context ());
 
+	// 현재 스레드를 ready_list에 넣는 동안 인터럽트가 발생하면 안 된다. 인터럽트가 발생하면 스케줄링이 일어나서 ready_list가 변경될 수 있기 때문이다.
+	// 그래서 꺼준다.
 	old_level = intr_disable ();
-	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
+	
+	// idle thread는 ready_list에 넣지 않고, ready thread 가 하나도 없을 때에만 실행한다. cpu가 노는걸 방지하기 위해서이다.
+	// 여기서는 현재 current thread가 idle thread가 아니라면, ready_list에 다시 넣어준다.
+	if (curr != idle_thread) { 
+		// 다시 ready 상태가 되는 순간에도, 우선순위 순서를 유지해야 한다.
+	// 두 스레드를 비교하는 함수를 통해, ready_list에 current thread를 우선순위에 맞게 삽입한다.
+		list_insert_ordered (&ready_list, &curr->elem, thread_priority_compare, NULL);
+	}
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
 }
 
-/* 현재 thread의 priority를 NEW_PRIORITY로 설정한다. */
+/* Sets the current thread's priority to NEW_PRIORITY. */
+
+// 현재 스레드가 priority를 낮췄을 때, ready 상태의 더 높은 스레드에게 바로 cpu를 양보하도록 함.
 void
 thread_set_priority (int new_priority) {
 	thread_current ()->priority = new_priority;
+
+	struct thread *curr = thread_current ();
+
+	// 현재 스레드의 우선순위를 새 값으로 갱신한다.
+	curr->priority = new_priority;
+
+	// ready list는 이미 정렬 되어있다.
+	// 그래서 ready list의 맨 앞 원소만 보면, 현재 ready 상태인 스레드 중에 가장 높은 우선순위인 스레드를 알 수 있다.
+	if (!list_empty (&ready_list)) {
+		struct thread *front = list_entry (list_front (&ready_list), struct thread, elem);
+
+		// 그런데, 만약에 ready list 맨 앞 원소의 우선순위가 현재 스레드의 우선순위보다 높다면, 
+		if (front->priority > curr->priority) {
+			// 현재 스레드는 yield하여 CPU를 양보하도록 한다.
+			thread_yield ();
+		}
+	}	
 }
 
-/* 현재 thread의 priority를 반환한다. */
+/* Returns the current thread's priority. */
 int
 thread_get_priority (void) {
 	return thread_current ()->priority;
 }
 
-/* 현재 thread의 nice 값을 NICE로 설정한다. */
+/* Sets the current thread's nice value to NICE. */
 void
 thread_set_nice (int nice UNUSED) {
-	/* TODO: 여기에 구현을 추가하세요 */
+	/* TODO: Your implementation goes here */
 }
 
-/* 현재 thread의 nice 값을 반환한다. */
+/* Returns the current thread's nice value. */
 int
 thread_get_nice (void) {
-	/* TODO: 여기에 구현을 추가하세요 */
+	/* TODO: Your implementation goes here */
 	return 0;
 }
 
-/* system load average의 100배 값을 반환한다. */
+/* Returns 100 times the system load average. */
 int
 thread_get_load_avg (void) {
-	/* TODO: 여기에 구현을 추가하세요 */
+	/* TODO: Your implementation goes here */
 	return 0;
 }
 
-/* 현재 thread의 recent_cpu 값의 100배를 반환한다. */
+/* Returns 100 times the current thread's recent_cpu value. */
 int
 thread_get_recent_cpu (void) {
-	/* TODO: 여기에 구현을 추가하세요 */
+	/* TODO: Your implementation goes here */
 	return 0;
 }
 
-/* idle thread. 다른 어떤 thread도 실행 준비가 되어 있지 않을 때 실행된다.
-   idle thread는 처음에 thread_start()에 의해 ready list에 들어간다.
-   처음 한 번 스케줄되면 idle_thread를 초기화하고, 전달받은 semaphore를
-   "up"하여 thread_start()가 계속 진행할 수 있게 한 다음 즉시 block된다.
-   그 이후로 idle thread는 ready list에 다시 나타나지 않는다.
-   ready list가 비어 있을 때는 특수한 경우로 next_thread_to_run()이
-   이를 반환한다. */
+/* Idle thread.  Executes when no other thread is ready to run.
+
+   The idle thread is initially put on the ready list by
+   thread_start().  It will be scheduled once initially, at which
+   point it initializes idle_thread, "up"s the semaphore passed
+   to it to enable thread_start() to continue, and immediately
+   blocks.  After that, the idle thread never appears in the
+   ready list.  It is returned by next_thread_to_run() as a
+   special case when the ready list is empty. */
 static void
 idle (void *idle_started_ UNUSED) {
 	struct semaphore *idle_started = idle_started_;
@@ -347,33 +420,39 @@ idle (void *idle_started_ UNUSED) {
 	sema_up (idle_started);
 
 	for (;;) {
-		/* 다른 누군가가 실행되게 한다. */
+		/* Let someone else run. */
 		intr_disable ();
 		thread_block ();
 
-		/* interrupt를 다시 켜고 다음 interrupt를 기다린다.
-		   `sti' 명령은 다음 명령이 끝날 때까지 interrupt를 비활성화하므로,
-		   이 두 명령은 원자적으로 실행된다. 이 원자성은 중요하다.
-		   그렇지 않으면 interrupt를 다시 켠 뒤 다음 interrupt를 기다리기 전에
-		   interrupt가 처리되어 최대 한 clock tick만큼 시간을 낭비할 수 있다.
-		   자세한 내용은 [IA32-v2a] "HLT", [IA32-v2b] "STI",
-		   [IA32-v3a] 7.11.1 "HLT Instruction"을 참고하라. */
+		/* Re-enable interrupts and wait for the next one.
+
+		   The `sti' instruction disables interrupts until the
+		   completion of the next instruction, so these two
+		   instructions are executed atomically.  This atomicity is
+		   important; otherwise, an interrupt could be handled
+		   between re-enabling interrupts and waiting for the next
+		   one to occur, wasting as much as one clock tick worth of
+		   time.
+
+		   See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
+		   7.11.1 "HLT Instruction". */
 		asm volatile ("sti; hlt" : : : "memory");
 	}
 }
 
-/* kernel thread의 기반으로 사용하는 함수. */
+/* Function used as the basis for a kernel thread. */
 static void
 kernel_thread (thread_func *function, void *aux) {
 	ASSERT (function != NULL);
 
-	intr_enable ();       /* scheduler는 interrupt를 끈 상태로 실행된다. */
-	function (aux);       /* thread 함수를 실행한다. */
-	thread_exit ();       /* function()이 반환되면 thread를 종료한다. */
+	intr_enable ();       /* The scheduler runs with interrupts off. */
+	function (aux);       /* Execute the thread function. */
+	thread_exit ();       /* If function() returns, kill the thread. */
 }
 
 
-/* T를 NAME이라는 이름의 blocked thread로 기본 초기화한다. */
+/* Does basic initialization of T as a blocked thread named
+   NAME. */
 static void
 init_thread (struct thread *t, const char *name, int priority) {
 	ASSERT (t != NULL);
@@ -388,10 +467,11 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->magic = THREAD_MAGIC;
 }
 
-/* 다음에 스케줄할 thread를 선택해 반환한다. run queue가 비어 있지 않다면
-   run queue에서 thread를 반환해야 한다. (현재 실행 중인 thread가 계속
-   실행될 수 있다면 그 thread도 run queue 안에 있다.) run queue가 비어
-   있으면 idle_thread를 반환한다. */
+/* Chooses and returns the next thread to be scheduled.  Should
+   return a thread from the run queue, unless the run queue is
+   empty.  (If the running thread can continue running, then it
+   will be in the run queue.)  If the run queue is empty, return
+   idle_thread. */
 static struct thread *
 next_thread_to_run (void) {
 	if (list_empty (&ready_list))
@@ -400,7 +480,7 @@ next_thread_to_run (void) {
 		return list_entry (list_pop_front (&ready_list), struct thread, elem);
 }
 
-/* iretq를 사용해 thread를 시작한다. */
+/* Use iretq to launch the thread */
 void
 do_iret (struct intr_frame *tf) {
 	__asm __volatile(
@@ -428,28 +508,33 @@ do_iret (struct intr_frame *tf) {
 			: : "g" ((uint64_t) tf) : "memory");
 }
 
-/* 새 thread의 page table을 활성화해 thread를 전환하고,
-   이전 thread가 dying 상태라면 그것을 파기한다.
-   이 함수가 호출될 시점에는 PREV thread에서 막 전환된 직후이고,
-   새 thread는 이미 실행 중이며 interrupt는 여전히 비활성화되어 있다.
-   thread 전환이 끝나기 전까지 printf()를 호출하는 것은 안전하지 않다.
-   실제로는 함수 끝부분에만 printf()를 추가해야 한다는 뜻이다. */
+/* Switching the thread by activating the new thread's page
+   tables, and, if the previous thread is dying, destroying it.
+
+   At this function's invocation, we just switched from thread
+   PREV, the new thread is already running, and interrupts are
+   still disabled.
+
+   It's not safe to call printf() until the thread switch is
+   complete.  In practice that means that printf()s should be
+   added at the end of the function. */
 static void
 thread_launch (struct thread *th) {
 	uint64_t tf_cur = (uint64_t) &running_thread ()->tf;
 	uint64_t tf = (uint64_t) &th->tf;
 	ASSERT (intr_get_level () == INTR_OFF);
 
-	/* 핵심 전환 로직.
-	 * 먼저 전체 실행 context를 intr_frame에 복구한 뒤
-	 * do_iret를 호출해 다음 thread로 전환한다.
-	 * 여기서부터 전환이 끝날 때까지는 어떤 stack도 사용하면 안 된다. */
+	/* The main switching logic.
+	 * We first restore the whole execution context into the intr_frame
+	 * and then switching to the next thread by calling do_iret.
+	 * Note that, we SHOULD NOT use any stack from here
+	 * until switching is done. */
 	__asm __volatile (
-			/* 사용할 레지스터를 저장한다. */
+			/* Store registers that will be used. */
 			"push %%rax\n"
 			"push %%rbx\n"
 			"push %%rcx\n"
-			/* 입력을 한 번만 읽는다. */
+			/* Fetch input once */
 			"movq %0, %%rax\n"
 			"movq %1, %%rcx\n"
 			"movq %%r15, 0(%%rax)\n"
@@ -464,17 +549,17 @@ thread_launch (struct thread *th) {
 			"movq %%rdi, 72(%%rax)\n"
 			"movq %%rbp, 80(%%rax)\n"
 			"movq %%rdx, 88(%%rax)\n"
-			"pop %%rbx\n"              // 저장해 둔 rcx
+			"pop %%rbx\n"              // Saved rcx
 			"movq %%rbx, 96(%%rax)\n"
-			"pop %%rbx\n"              // 저장해 둔 rbx
+			"pop %%rbx\n"              // Saved rbx
 			"movq %%rbx, 104(%%rax)\n"
-			"pop %%rbx\n"              // 저장해 둔 rax
+			"pop %%rbx\n"              // Saved rax
 			"movq %%rbx, 112(%%rax)\n"
 			"addq $120, %%rax\n"
 			"movw %%es, (%%rax)\n"
 			"movw %%ds, 8(%%rax)\n"
 			"addq $32, %%rax\n"
-			"call __next\n"         // 현재 rip를 읽는다.
+			"call __next\n"         // read the current rip.
 			"__next:\n"
 			"pop %%rbx\n"
 			"addq $(out_iret -  __next), %%rbx\n"
@@ -492,10 +577,10 @@ thread_launch (struct thread *th) {
 			);
 }
 
-/* 새 프로세스를 스케줄한다. 진입 시점에는 interrupt가 꺼져 있어야 한다.
- * 이 함수는 현재 thread의 status를 status로 바꾼 뒤
- * 실행할 다른 thread를 찾아 전환한다.
- * schedule() 안에서 printf()를 호출하는 것은 안전하지 않다. */
+/* Schedules a new process. At entry, interrupts must be off.
+ * This function modify current thread's status to status and then
+ * finds another thread to run and switches to it.
+ * It's not safe to call printf() in the schedule(). */
 static void
 do_schedule(int status) {
 	ASSERT (intr_get_level () == INTR_OFF);
@@ -517,35 +602,37 @@ schedule (void) {
 	ASSERT (intr_get_level () == INTR_OFF);
 	ASSERT (curr->status != THREAD_RUNNING);
 	ASSERT (is_thread (next));
-	/* 실행 중 상태로 표시한다. */
+	/* Mark us as running. */
 	next->status = THREAD_RUNNING;
 
-	/* 새 time slice를 시작한다. */
+	/* Start new time slice. */
 	thread_ticks = 0;
 
 #ifdef USERPROG
-	/* 새 address space를 활성화한다. */
+	/* Activate the new address space. */
 	process_activate (next);
 #endif
 
 	if (curr != next) {
-		/* 방금 전환해 나온 thread가 dying 상태라면 그 struct thread를
-		   파기한다. thread_exit()가 자기 발판을 스스로 걷어차지 않게
-		   하려면 이 작업은 늦게 이루어져야 한다.
-		   해당 페이지는 현재 stack이 사용 중이므로 여기서는 page free 요청만
-		   큐잉한다.
-		   실제 파기 로직은 schedule() 시작 부분에서 호출된다. */
+		/* If the thread we switched from is dying, destroy its struct
+		   thread. This must happen late so that thread_exit() doesn't
+		   pull out the rug under itself.
+		   We just queuing the page free reqeust here because the page is
+		   currently used by the stack.
+		   The real destruction logic will be called at the beginning of the
+		   schedule(). */
 		if (curr && curr->status == THREAD_DYING && curr != initial_thread) {
 			ASSERT (curr != next);
 			list_push_back (&destruction_req, &curr->elem);
 		}
 
-		/* thread를 전환하기 전에 먼저 현재 실행 중인 thread의 정보를 저장한다. */
+		/* Before switching the thread, we first save the information
+		 * of current running. */
 		thread_launch (next);
 	}
 }
 
-/* 새 thread에 사용할 tid를 반환한다. */
+/* Returns a tid to use for a new thread. */
 static tid_t
 allocate_tid (void) {
 	static tid_t next_tid = 1;


### PR DESCRIPTION
## 작업 요약
- priority scheduling 구현으로 ready_list FIFO 문제 해결
- thread.c: implemented priority ordered ready_list insertion, preemption on
- thread_create(), yield on priority decrease, and thread_priority_compare()

## 목표 테스트
- [V] make tests/threads/priority-fifo.result
- [V] make tests/threads/priority-preempt.result
- [V] make tests/threads/priority-change.result
- [V] make tests/threads/alarm-priority.result

## 구현 전 의사코드

```
thread_priority_compare(a, b):

1. list_elem a, b를 struct thread로 변환
2. if a.priority > b.priority: return true
3. else return false
같은 priority면 false를 반환하여 기존 FIFO 순서 유지
4. thread_unblock(t):

old_level = intr_disable()
1. t가 BLOCKED 상태인지 확인
2. ready_list에 t를 priority 내림차순으로 삽입
3. t.status = THREAD_READY
4. intr_set_level(old_level)
5. thread_yield():

old_level = intr_disable()
1. 현재 스레드가 idle_thread가 아니면 ready_list에 priority 순으로 삽입
2. do_schedule(THREAD_READY)
3. intr_set_level(old_level)
4. thread_create():

새 스레드 생성 및 초기화
1. thread_unblock(new_thread)
2. if new_thread.priority > current_thread.priority:
3. current_thread가 thread_yield()로 CPU 양보
4. thread_set_priority(new_priority):

current_thread.priority = new_priority
1. ready_list가 비어 있지 않으면 front thread 확인
2. if front.priority > current_thread.priority:
3. current_thread가 thread_yield()로 CPU 양보
```

## 유지해야 할 invariant
- ready_list는 priority 기준 내림차순을 유지한다.
- 같은 priority를 가진 스레드들은 FIFO 순서를 유지한다.
- ready_list의 front는 항상 READY 상태 중 가장 높은 priority 스레드다.
- 더 높은 priority 스레드가 READY 상태가 되면 현재 스레드는 즉시 CPU를 양보해야 한다.
- 현재 스레드가 priority를 낮췄을 때 더 높은 priority의 READY 스레드가 있으면 즉시 yield해야 한다.

## 구현 내용
- thread_priority_compare(): ready_list 정렬 기준 함수 구현
- thread_unblock(): ready_list 삽입을 list_push_back()에서 priority ordered insert로 변경
- thread_yield(): yield 후 READY 상태로 돌아갈 때도 priority ordered insert 사용
- thread_create(): 새로 생성된 스레드의 priority가 더 높으면 즉시 선점되도록 구현
- thread_set_priority(): 현재 스레드 priority 변경 후 더 높은 priority READY 스레드가 있으면 yield하도록 구현
- next_thread_to_run(): ready_list가 이미 정렬되어 있으므로 기존 front pop 구조 유지

## 테스트 결과

ALL PASS (4 tests above)