### PR TITLE
feat(donation): implement priority donation

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -87,11 +87,17 @@ struct thread {
 	tid_t tid;                          /* Thread identifier. */
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
-	int priority;                       /* Priority. */
+	int priority;                       /* Effective priority. */
+	int base_priority;									/* Base priority, donation 구현을 위해 추가 */
 	int64_t wakeup_ticks;								/* 잠든 스레드가 깨어날 수 있는 최소 절대 tick. */
 
 	/* thread.c와 synch.c가 공유한다. */
-	struct list_elem elem;              /* list 원소. */
+	struct list_elem elem;              /* ready_list, semaphore waiters 원소. */
+	
+	/* donation 구현을 위해 추가하는 구조체 멤버들 */
+	struct list_elem donation_elem;			/* /* 다른 thread의 donations 리스트에 들어갈 때 쓰는 elem. */
+	struct list donations;							/* /* 나에게 priority를 donation한 thread들의 리스트. */
+	struct lock *wait_lock;							/* 이 스레드가 현재 기다리고 있는 lock의 주소. 없으면 NULL*/
 
 #ifdef USERPROG
 	/* userprog/process.c가 소유한다. */
@@ -119,10 +125,14 @@ void thread_tick (void);
 void thread_print_stats (void);
 
 typedef void thread_func (void *aux);
-tid_t thread_create (const char *name, int priority, thread_func *, void *);
+tid_t thread_create (const char *, int, thread_func *, void *);
 
 void thread_block (void);
 void thread_unblock (struct thread *);
+
+void refresh_priority(struct thread *);
+void donate_priority (struct thread *, struct thread *);
+void remove_donation (struct lock *);
 
 struct thread *thread_current (void);
 tid_t thread_tid (void);

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -87,17 +87,17 @@ struct thread {
 	tid_t tid;                          /* Thread identifier. */
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
-	int priority;                       /* Effective priority. */
-	int base_priority;									/* Base priority, donation 구현을 위해 추가 */
+	int priority;                       /* donation이 반영된 유효 우선순위. */
+	int base_priority;									/* donation 제거 후 돌아갈 원래 priority. */
 	int64_t wakeup_ticks;								/* 잠든 스레드가 깨어날 수 있는 최소 절대 tick. */
 
 	/* thread.c와 synch.c가 공유한다. */
 	struct list_elem elem;              /* ready_list, semaphore waiters 원소. */
 	
-	/* donation 구현을 위해 추가하는 구조체 멤버들 */
-	struct list_elem donation_elem;			/* /* 다른 thread의 donations 리스트에 들어갈 때 쓰는 elem. */
-	struct list donations;							/* /* 나에게 priority를 donation한 thread들의 리스트. */
-	struct lock *wait_lock;							/* 이 스레드가 현재 기다리고 있는 lock의 주소. 없으면 NULL*/
+	/* 우선순위 기부 상태. */
+	struct list_elem donation_elem;			/* 이 thread가 다른 thread의 donations 리스트에 들어갈 때 쓰는 elem. */
+	struct list donations;							/* 이 thread에게 priority를 기부한 donor thread들의 목록. */
+	struct lock *wait_lock;							/* 이 thread가 현재 기다리는 lock. 기다리는 lock이 없으면 NULL. */
 
 #ifdef USERPROG
 	/* userprog/process.c가 소유한다. */
@@ -130,8 +130,14 @@ tid_t thread_create (const char *, int, thread_func *, void *);
 void thread_block (void);
 void thread_unblock (struct thread *);
 
+/* 우선순위 기부 보조 함수들. */
+/* base_priority와 donations를 기준으로 thread의 유효 우선순위를 다시 계산한다. */
 void refresh_priority(struct thread *);
+
+/* donor가 receiver에게 priority를 기부하고 필요한 경우 lock holder chain 위로 전파한다. */
 void donate_priority (struct thread *, struct thread *);
+
+/* 현재 thread가 lock을 해제할 때 해당 lock 때문에 받은 donation을 제거한다. */
 void remove_donation (struct lock *);
 
 struct thread *thread_current (void);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -181,41 +181,27 @@ void lock_init(struct lock *lock)
    interrupt는 다시 활성화된다. */
 void lock_acquire(struct lock *lock)
 {
-	// 현재 실행 중인 thread를 가져온다.
-	struct thread *curr= thread_current();
-	// donation chain을 따라 올라갈 때 사용할 holder 포인터다.
-	struct thread *holder;
 
 	ASSERT(lock != NULL);
 	ASSERT(!intr_context());
 	ASSERT(!lock_held_by_current_thread(lock));
 
+	// 현재 실행 중인 thread를 가져온다.
+	struct thread *curr= thread_current();
+	// donation chain을 따라 올라갈 때 사용할 holder 포인터다.
+	struct thread *holder = lock->holder;
+	
 	// 현재 thread가 어떤 lock을 기다리는지 기록한다.
-  	// nested donation 전파에서 chain을 따라가기 위해 필요하다.
+  // nested donation 전파에서 chain을 따라가기 위해 필요하다.
 	curr->wait_lock = lock;
 
 	// 이미 누군가 lock을 들고 있으면 donation이 필요할 수 있다.
-  	if (lock->holder != NULL) {
-		// 현재 thread가 직접 기다리는 lock holder에게 donation을 건다.
-		// 1. 조건을 거는 것이 효율적일 거 같다. donor가 receiver보다 우선순위가 높을 때만 donation한다.
-		donate_priority (curr, lock->holder);
-
-		// 첫 holder부터 시작해서 donation chain을 따라 올라간다.
-		holder = lock->holder;
-		// 기다리고 있는 lock이 있고, 그 lock을 들고 있는 thread가 있으면 계속 올라간다.
-		// 2. 이게 donate_priority를 한 번 하고 while문을 도는 거기 때문에, 
-		// 내부적으로 연쇄작용이 일어나는 건 donate_priority 안에서 일어나는 게 맞는 거 같다.
-		// 코드 책임 관점에서 보았을 땐... 그런 거 같긴 한데... 뭐가 더 나을까...
-		while (holder->wait_lock != NULL && holder->wait_lock->holder != NULL) {
-			// holder가 또 기다리고 있는 lock의 holder로 이동한다.
-			holder = holder->wait_lock->holder;
-			
-			// 현재 thread의 priority가 더 높으면 위쪽 holder의 effective priority를 끌어올린다.
-      		// 여기서는 같은 donation_elem을 여러 리스트에 넣지 않고 값만 전파한다.
-			if(curr->priority > holder->priority) {
-				holder->priority = curr->priority;
+  	if (holder != NULL) {
+			// 현재 thread가 직접 기다리는 lock holder에게 donation을 건다.
+			// 1. 조건을 거는 것이 효율적일 거 같다. donor가 receiver보다 우선순위가 높을 때만 donation한다.
+			if (holder->priority < curr->priority) {
+				donate_priority (curr, holder); // donate_priority() 내부에서 연쇄 작용이 일어난다.
 			}
-		}
 	}
 
 	// 실제 lock semaphore를 down해서 lock이 풀릴 때까지 기다린다.

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -182,34 +182,43 @@ void lock_init(struct lock *lock)
 void lock_acquire(struct lock *lock)
 {
 
+	/* lock 인자가 반드시 유효해야 이후 holder와 semaphore에 접근할 수 있다. */
 	ASSERT(lock != NULL);
+
+	/* lock_acquire()는 block될 수 있으므로 interrupt handler 안에서 호출하면 안 된다. */
 	ASSERT(!intr_context());
+
+	/* Pintos lock은 재귀 획득을 허용하지 않으므로 현재 thread가 이미 들고 있으면 안 된다. */
 	ASSERT(!lock_held_by_current_thread(lock));
 
-	// 현재 실행 중인 thread를 가져온다.
-	struct thread *curr= thread_current();
-	// donation chain을 따라 올라갈 때 사용할 holder 포인터다.
+	/* donation의 donor가 될 현재 실행 중인 thread를 가져온다. */
+	struct thread *curr = thread_current();
+
+	/* 현재 lock을 이미 들고 있는 thread가 있으면 donation의 직접 receiver가 된다. */
 	struct thread *holder = lock->holder;
 	
-	// 현재 thread가 어떤 lock을 기다리는지 기록한다.
-  // nested donation 전파에서 chain을 따라가기 위해 필요하다.
+	/* 현재 스레드가 기다리는 lock을 기록한다.
+	   donation 제거와 중첩 기부 체인 추적에서 이 값으로 원인을 구분한다. */
 	curr->wait_lock = lock;
 
-	// 이미 누군가 lock을 들고 있으면 donation이 필요할 수 있다.
-  	if (holder != NULL) {
-			// 현재 thread가 직접 기다리는 lock holder에게 donation을 건다.
-			// 1. 조건을 거는 것이 효율적일 거 같다. donor가 receiver보다 우선순위가 높을 때만 donation한다.
-			if (holder->priority < curr->priority) {
-				donate_priority (curr, holder); // donate_priority() 내부에서 연쇄 작용이 일어난다.
-			}
+	/* lock이 이미 점유되어 있고 현재 스레드가 holder보다 높을 때만 donation을 시작한다.
+	   보유자 체인으로의 추가 전파는 donate_priority()가 담당한다. */
+	if (holder != NULL) {
+		/* 현재 thread의 priority가 더 높을 때만 holder의 priority를 끌어올릴 필요가 있다. */
+		if (holder->priority < curr->priority) {
+			/* 현재 thread가 lock holder에게 priority를 기부하고, 필요하면 chain 위로 전파한다. */
+			donate_priority (curr, holder);
+		}
 	}
 
-	// 실제 lock semaphore를 down해서 lock이 풀릴 때까지 기다린다.
+	/* semaphore가 열릴 때까지 대기한다. 깨어나 lock을 얻으면 대기 상태를 해제한다. */
 	sema_down(&lock->semaphore);
-	// lock을 획득했으므로 더 이상 기다리는 lock은 없다.
-  	curr->wait_lock = NULL;
-  	// 이제 이 lock의 holder는 현재 thread가 된다.
- 	lock->holder = curr;
+
+	/* lock 획득에 성공했으므로 현재 thread는 더 이상 어떤 lock도 기다리지 않는다. */
+	curr->wait_lock = NULL;
+
+	/* semaphore 획득이 끝난 현재 thread를 lock의 새 holder로 기록한다. */
+	lock->holder = curr;
 }
 
 /* LOCK 획득을 시도하고, 성공하면 true, 실패하면 false를 반환한다.
@@ -234,21 +243,24 @@ bool lock_try_acquire(struct lock *lock)
    lock을 해제하려고 시도하는 것은 의미가 없다. */
 void lock_release(struct lock *lock)
 {
+	/* 해제할 lock 인자가 유효한지 확인한다. */
 	ASSERT(lock != NULL);
+
+	/* 현재 thread가 실제로 들고 있는 lock만 해제할 수 있다. */
 	ASSERT(lock_held_by_current_thread(lock));
 
-	// 이 lock 때문에 받은 donation만 donation 목록에서 제거한다.
-  remove_donation (lock);
+	/* 이 lock 때문에 받은 donation만 제거한 뒤,
+	   남아 있는 donation과 base priority를 기준으로 유효 우선순위를 다시 계산한다. */
+	remove_donation (lock);
 
-  // 남아 있는 donation들과 base priority를 기준으로
- 	// 현재 thread의 effective priority를 다시 계산한다.
- 	refresh_priority (thread_current ());
+	/* donation 제거 후 현재 thread의 priority를 base priority 또는 남은 donation 기준으로 복구한다. */
+	refresh_priority (thread_current ());
 
-  // lock을 더 이상 누구도 들고 있지 않도록 holder를 NULL로 만든다.
-  lock->holder = NULL;
+	/* holder를 비운 뒤 semaphore를 올려 waiters 중 하나가 lock 획득을 재시도하게 한다. */
+	lock->holder = NULL;
 
-  // semaphore를 up해서 lock을 기다리던 thread 하나를 깨운다.
-  sema_up (&lock->semaphore);
+	/* lock을 기다리던 thread 중 하나를 깨워 lock 획득을 다시 시도하게 한다. */
+	sema_up (&lock->semaphore);
 }
 
 /* 현재 thread가 LOCK을 가지고 있으면 true, 아니면 false를 반환한다.

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -99,6 +99,7 @@ void sema_up(struct semaphore *sema)
 	/* sema_down()에서 waiters를 priority 내림차순으로 유지하므로
 	   front가 이번 sema_up()에서 깨울 가장 높은 priority thread다. */
 	if (!list_empty (&sema->waiters)) {
+		list_sort(&sema->waiters, thread_priority_compare, NULL);
 		t = list_entry (list_pop_front (&sema->waiters),
                                 struct thread, elem);
 		thread_unblock (t);
@@ -180,12 +181,49 @@ void lock_init(struct lock *lock)
    interrupt는 다시 활성화된다. */
 void lock_acquire(struct lock *lock)
 {
+	// 현재 실행 중인 thread를 가져온다.
+	struct thread *curr= thread_current();
+	// donation chain을 따라 올라갈 때 사용할 holder 포인터다.
+	struct thread *holder;
+
 	ASSERT(lock != NULL);
 	ASSERT(!intr_context());
 	ASSERT(!lock_held_by_current_thread(lock));
 
+	// 현재 thread가 어떤 lock을 기다리는지 기록한다.
+  	// nested donation 전파에서 chain을 따라가기 위해 필요하다.
+	curr->wait_lock = lock;
+
+	// 이미 누군가 lock을 들고 있으면 donation이 필요할 수 있다.
+  	if (lock->holder != NULL) {
+		// 현재 thread가 직접 기다리는 lock holder에게 donation을 건다.
+		// 1. 조건을 거는 것이 효율적일 거 같다. donor가 receiver보다 우선순위가 높을 때만 donation한다.
+		donate_priority (curr, lock->holder);
+
+		// 첫 holder부터 시작해서 donation chain을 따라 올라간다.
+		holder = lock->holder;
+		// 기다리고 있는 lock이 있고, 그 lock을 들고 있는 thread가 있으면 계속 올라간다.
+		// 2. 이게 donate_priority를 한 번 하고 while문을 도는 거기 때문에, 
+		// 내부적으로 연쇄작용이 일어나는 건 donate_priority 안에서 일어나는 게 맞는 거 같다.
+		// 코드 책임 관점에서 보았을 땐... 그런 거 같긴 한데... 뭐가 더 나을까...
+		while (holder->wait_lock != NULL && holder->wait_lock->holder != NULL) {
+			// holder가 또 기다리고 있는 lock의 holder로 이동한다.
+			holder = holder->wait_lock->holder;
+			
+			// 현재 thread의 priority가 더 높으면 위쪽 holder의 effective priority를 끌어올린다.
+      		// 여기서는 같은 donation_elem을 여러 리스트에 넣지 않고 값만 전파한다.
+			if(curr->priority > holder->priority) {
+				holder->priority = curr->priority;
+			}
+		}
+	}
+
+	// 실제 lock semaphore를 down해서 lock이 풀릴 때까지 기다린다.
 	sema_down(&lock->semaphore);
-	lock->holder = thread_current();
+	// lock을 획득했으므로 더 이상 기다리는 lock은 없다.
+  	curr->wait_lock = NULL;
+  	// 이제 이 lock의 holder는 현재 thread가 된다.
+ 	lock->holder = curr;
 }
 
 /* LOCK 획득을 시도하고, 성공하면 true, 실패하면 false를 반환한다.
@@ -213,8 +251,18 @@ void lock_release(struct lock *lock)
 	ASSERT(lock != NULL);
 	ASSERT(lock_held_by_current_thread(lock));
 
-	lock->holder = NULL;
-	sema_up(&lock->semaphore);
+	// 이 lock 때문에 받은 donation만 donation 목록에서 제거한다.
+  remove_donation (lock);
+
+  // 남아 있는 donation들과 base priority를 기준으로
+ 	// 현재 thread의 effective priority를 다시 계산한다.
+ 	refresh_priority (thread_current ());
+
+  // lock을 더 이상 누구도 들고 있지 않도록 holder를 NULL로 만든다.
+  lock->holder = NULL;
+
+  // semaphore를 up해서 lock을 기다리던 thread 하나를 깨운다.
+  sema_up (&lock->semaphore);
 }
 
 /* 현재 thread가 LOCK을 가지고 있으면 true, 아니면 false를 반환한다.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -55,6 +55,83 @@ bool thread_priority_compare(const struct list_elem *a, const struct list_elem *
 	return ta->priority > tb->priority;
 }
 
+/* donations에 들어가는 donation_elem을 thread priority 기준으로 비교한다. */
+bool donor_priority_compare(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED)
+{
+
+	/* donations의 elem은 struct thread가 아니라 struct thread의 donation_elem이다. */
+	const struct thread *da = list_entry(a, struct thread, donation_elem);
+	const struct thread *db = list_entry(b, struct thread, donation_elem);
+
+	return da->priority > db->priority;
+}
+
+// thread의 우선순위를 갱신한다. base_priority에서 시작하여, 현재 스레드에 기부된 우선순위 중 가장 높은 값을 적용한다.
+void refresh_priority(struct thread *t)
+{
+	// base_priority에서 시작하여, 현재 스레드에 기부된 우선순위 중 가장 높은 값을 적용한다.
+	t->priority = t->base_priority;
+
+	// t->donations이 비어 있지 않으면, 가장 높은 우선순위를 가진 기부자 스레드의 우선순위를 현재 스레드에 적용한다.
+	if (!list_empty(&t->donations))
+	{
+		// t->donations은 우선순위 내림차순에 따라 삽입되므로, 일반적으로는 맨 앞 원소가 가장 높은 우선순위를 가지지만
+		// nested donation에 따라 삽입 이후 donor의 priority가 변경 정렬 기준이 망가질 수 있으므로, 선택 전에 정렬을 새로 한 번 해주는 것이 필요하다. 
+		list_sort(&t->donations, donor_priority_compare, NULL);
+		struct thread *donor = list_entry(list_front(&t->donations), struct thread, donation_elem);
+		// donor의 우선순위가 현재 스레드보다 높으면, donor의 우선순위를 현재 스레드에 적용한다.
+		if (donor->priority > t->priority)
+		{
+			t->priority = donor->priority;
+		}
+	}
+}
+
+// 우선순위 기부 함수. donor가 receiver에게 priority를 기부한다.
+void donate_priority (struct thread *donor, struct thread *receiver) {
+	
+	// donor와 receiver가 유효한 스레드인지 확인한다.
+	if (donor == NULL || receiver == NULL ) {
+		return;
+	}
+
+	// receiver의 donations 리스트에 donor를 우선순위 순서로 삽입한다.
+	list_insert_ordered(&receiver->donations, &donor->donation_elem, donor_priority_compare, NULL);
+
+	// donation 추가 후 receiver의 effective priority를 다시 계산한다.
+	refresh_priority(receiver);
+	// donor의 우선순위가 receiver보다 높으면, donor의 우선순위를 receiver에 적용한다.
+	// if (donor->priority > receiver->priority) {
+	// 	receiver->priority = donor->priority;
+	// }
+}
+
+// lock이 해제될 때, 해당 lock에 대해 기부된 우선순위를 제거한다.
+void remove_donation (struct lock *lock) {
+	
+	// 현재 스레드
+	struct thread *curr = thread_current();
+	// 리스트 원소 포인터
+	struct list_elem *e = list_begin (&curr->donations);
+
+	// curr->donations 리스트를 순회하면서, lock에 대해 기부된 우선순위를 제거한다.
+	while (e != list_end (&curr->donations)) {
+		
+		// list_elem에서 thread 구조체 포인터를 얻는다.
+		struct thread *donor = list_entry(e, struct thread, donation_elem);
+		struct list_elem *next = list_next(e);
+
+		// donor가 기다리는 락이 lock과 일치하면, donor를 curr->donations 리스트에서 제거한다.
+		if (donor->wait_lock == lock) {
+			list_remove(e);
+		}
+		// 다음 리스트 원소로 이동한다.
+		e = next;
+	}
+}
+
+
+
 /* 통계 정보. */
 static long long idle_ticks;   /* 유휴 상태에서 소비한 타이머 틱 수. */
 static long long kernel_ticks; /* 커널 스레드에서 소비한 타이머 틱 수. */
@@ -345,7 +422,9 @@ void thread_set_priority(int new_priority)
 	struct thread *curr = thread_current();
 
 	// 현재 스레드의 우선순위를 새 값으로 갱신한다.
-	curr->priority = new_priority;
+	curr->base_priority = new_priority;
+	refresh_priority(curr);
+	
 
 	// ready_list는 이미 우선순위 순서로 정렬되어 있다.
 	// 따라서 맨 앞 원소가 READY 상태 스레드 중 가장 높은 우선순위를 가진다.
@@ -453,6 +532,11 @@ init_thread(struct thread *t, const char *name, int priority)
 	strlcpy(t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
 	t->priority = priority;
+	/* 여기부터 */
+	t->base_priority = priority;
+	t->wait_lock = NULL;
+	list_init(&t->donations);
+	/* 여기까지 추가 */ 
 	t->magic = THREAD_MAGIC;
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -40,111 +40,120 @@ static struct lock tid_lock;
 /* 제거 대기 중인 스레드 목록. */
 static struct list destruction_req;
 
-// thread.elem으로 구성된 리스트에서 어떤 스레드가 앞에 와야 하는지 비교한다.
-// ready_list와 semaphore waiters는 모두 thread.elem을 담으므로 같은 비교 함수를 공유한다.
-// 우선순위가 같으면 false를 반환하여 기존 삽입 순서를 유지한다.
+/* thread.elem으로 구성된 리스트를 유효 우선순위 내림차순으로 정렬한다.
+   ready_list와 semaphore waiters는 모두 thread.elem을 담으므로 같은 비교 함수를 공유한다.
+   우선순위가 같으면 false를 반환하여 기존 삽입 순서를 유지한다. */
 bool thread_priority_compare(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED)
 {
-
-	// list_elem을 실제 thread 구조체 포인터로 변환한다.
+	/* ready_list나 semaphore waiters에 들어간 elem에서 첫 번째 thread를 꺼낸다. */
 	const struct thread *ta = list_entry(a, struct thread, elem);
+
+	/* ready_list나 semaphore waiters에 들어간 elem에서 두 번째 thread를 꺼낸다. */
 	const struct thread *tb = list_entry(b, struct thread, elem);
 
-	// 우선순위가 높은 스레드가 ready_list의 앞쪽에 오도록 한다.
-	// 같은 우선순위에서는 false가 되므로 FIFO 순서가 유지된다.
+	/* priority가 더 큰 thread가 리스트 앞쪽에 오도록 true를 반환한다. */
 	return ta->priority > tb->priority;
 }
 
-/* donations에 들어가는 donation_elem을 thread priority 기준으로 비교한다. */
+/* donations 리스트의 donation_elem을 기부자 스레드의 유효 우선순위 내림차순으로 정렬한다. */
 bool donor_priority_compare(const struct list_elem *a, const struct list_elem *b, void *aux UNUSED)
 {
-
-	/* donations의 elem은 struct thread가 아니라 struct thread의 donation_elem이다. */
+	/* donations 리스트에 들어간 donation_elem에서 첫 번째 donor thread를 꺼낸다. */
 	const struct thread *da = list_entry(a, struct thread, donation_elem);
+
+	/* donations 리스트에 들어간 donation_elem에서 두 번째 donor thread를 꺼낸다. */
 	const struct thread *db = list_entry(b, struct thread, donation_elem);
 
+	/* 더 높은 priority를 기부한 donor가 donations 리스트 앞쪽에 오도록 한다. */
 	return da->priority > db->priority;
 }
 
-// thread의 우선순위를 갱신한다. base_priority에서 시작하여, 현재 스레드에 기부된 우선순위 중 가장 높은 값을 적용한다.
+/* T의 유효 우선순위를 다시 계산한다.
+   base_priority를 기본값으로 두고, 현재 남아 있는 donations 중 가장 높은 값을 반영한다. */
 void refresh_priority(struct thread *t)
 {
-	// base_priority에서 시작하여, 현재 스레드에 기부된 우선순위 중 가장 높은 값을 적용한다.
+	/* donation이 모두 사라져도 원래 priority로 돌아갈 수 있도록 base_priority에서 시작한다. */
 	t->priority = t->base_priority;
 
-	// t->donations이 비어 있지 않으면, 가장 높은 우선순위를 가진 기부자 스레드의 우선순위를 현재 스레드에 적용한다.
+	/* 현재 thread가 받은 donation이 남아 있으면 가장 높은 donation을 반영해야 한다. */
 	if (!list_empty(&t->donations))
 	{
-		// t->donations은 우선순위 내림차순에 따라 삽입되므로, 일반적으로는 맨 앞 원소가 가장 높은 우선순위를 가지지만
-		// nested donation에 따라 삽입 이후 donor의 priority가 변경 정렬 기준이 망가질 수 있으므로, 선택 전에 정렬을 새로 한 번 해주는 것이 필요하다. 
+		/* 기부자의 priority는 중첩 기부 전파 중 삽입 이후에도 바뀔 수 있다.
+		   가장 높은 기부자를 고르기 전에 다시 정렬해 donations의 순서를 최신화한다. */
 		list_sort(&t->donations, donor_priority_compare, NULL);
+
+		/* 정렬 후 front는 현재 thread에게 가장 높은 priority를 기부한 donor다. */
 		struct thread *donor = list_entry(list_front(&t->donations), struct thread, donation_elem);
-		// donor의 우선순위가 현재 스레드보다 높으면, donor의 우선순위를 현재 스레드에 적용한다.
+
+		/* donor priority가 base priority보다 높을 때만 유효 우선순위를 끌어올린다. */
 		if (donor->priority > t->priority)
 		{
+			/* 가장 높은 donation 값을 현재 thread의 유효 우선순위로 반영한다. */
 			t->priority = donor->priority;
 		}
 	}
 }
 
-// 우선순위 기부 함수. donor가 receiver에게 priority를 기부한다.
+/* DONOR의 priority를 RECEIVER에게 기부한다.
+   직접 기부 관계는 RECEIVER의 donations에 기록해 lock_release() 때 제거할 수 있게 한다.
+   RECEIVER가 다른 lock을 기다리고 있으면 lock 보유자 체인을 따라 priority를 위로 전파한다. */
 void donate_priority (struct thread *donor, struct thread *receiver) {
-	
-	// donor와 receiver가 유효한 스레드인지 확인한다. -> 이미 호출 시에 확인이 됐는데 안전을 위해 다시 체크?
-	if (donor == NULL || receiver == NULL ) {
+	/* 잘못된 인자가 들어오면 donation 리스트를 건드리지 않고 종료한다. */
+	if (donor == NULL || receiver == NULL) {
 		return;
 	}
 
-	// receiver의 donations 리스트에 donor를 우선순위 순서로 삽입한다.
+	/* 현재 기부자가 직접 기다리는 lock의 보유자에게만 donation_elem을 연결한다.
+	   같은 donation_elem을 여러 donations 리스트에 동시에 넣을 수 없기 때문이다. */
 	list_insert_ordered(&receiver->donations, &donor->donation_elem, donor_priority_compare, NULL);
 
-	// donation 추가 후 receiver의 effective priority를 다시 계산한다.
+	/* 직접 donation을 받은 receiver의 유효 우선순위를 즉시 다시 계산한다. */
 	refresh_priority(receiver);
 	
-	// 기다리고 있는 lock이 있고, 그 lock을 들고 있는 thread가 있으면 계속 올라간다.
-	// 2. 이게 donate_priority를 한 번 하고 while문을 도는 거기 때문에, 
-	// 내부적으로 연쇄작용이 일어나는 건 donate_priority 안에서 일어나는 게 맞는 거 같다.
-	// 코드 책임 관점에서 보았을 땐... 그런 거 같긴 한데... 뭐가 더 나을까...
+	/* RECEIVER가 다시 다른 lock을 기다리는 중이면 중첩 기부를 전파한다.
+	   위쪽 보유자들은 직접 donation 리스트에 넣지 않고 유효 우선순위만 끌어올린다. */
 	while (receiver->wait_lock != NULL && receiver->wait_lock->holder != NULL) {
-		// holder가 또 기다리고 있는 lock의 holder로 이동한다.
+		/* receiver가 기다리는 lock의 holder로 이동해 다음 전파 대상을 잡는다. */
 		receiver = receiver->wait_lock->holder;
 				
-		// 현재 thread의 priority가 더 높으면 위쪽 holder의 effective priority를 끌어올린다.
-		// 여기서는 같은 donation_elem을 여러 리스트에 넣지 않고 값만 전파한다.
-		if(donor->priority > receiver->priority) {
+		/* donor priority가 위쪽 holder보다 높을 때만 priority inversion을 완화할 필요가 있다. */
+		if (donor->priority > receiver->priority) {
+			/* donation_elem을 추가로 연결하지 않고 유효 우선순위 값만 위로 전파한다. */
 			receiver->priority = donor->priority;
 		}
 		else {
+			/* 더 이상 priority가 올라가지 않으면 이후 체인에도 추가 전파가 필요 없다. */
 			break;
 		}
 	}
 }
 
-// lock이 해제될 때, 해당 lock에 대해 기부된 우선순위를 제거한다.
+/* 현재 스레드가 LOCK을 해제할 때, 그 lock 때문에 받은 donation만 제거한다. */
 void remove_donation (struct lock *lock) {
-	
-	// 현재 스레드
+	/* lock을 해제하는 현재 thread가 donation을 받은 주체다. */
 	struct thread *curr = thread_current();
-	// 리스트 원소 포인터
+
+	/* 현재 thread의 donations 리스트 처음부터 순회한다. */
 	struct list_elem *e = list_begin (&curr->donations);
 
-	// curr->donations 리스트를 순회하면서, lock에 대해 기부된 우선순위를 제거한다.
+	/* donations 전체를 훑으면서 이번 lock 때문에 들어온 donation만 찾는다. */
 	while (e != list_end (&curr->donations)) {
-		
-		// list_elem에서 thread 구조체 포인터를 얻는다.
+		/* donation_elem을 소유한 donor thread를 꺼낸다. */
 		struct thread *donor = list_entry(e, struct thread, donation_elem);
+
+		/* 현재 원소를 제거해도 순회를 계속할 수 있도록 다음 원소를 미리 저장한다. */
 		struct list_elem *next = list_next(e);
 
-		// donor가 기다리는 락이 lock과 일치하면, donor를 curr->donations 리스트에서 제거한다.
+		/* donor가 기다리는 lock이 방금 해제하는 lock이면 이 donation은 더 이상 유효하지 않다. */
 		if (donor->wait_lock == lock) {
+			/* 현재 thread의 donations 리스트에서 해당 donor를 제거한다. */
 			list_remove(e);
 		}
-		// 다음 리스트 원소로 이동한다.
+
+		/* 삭제 여부와 관계없이 미리 저장한 다음 원소로 이동한다. */
 		e = next;
 	}
 }
-
-
 
 /* 통계 정보. */
 static long long idle_ticks;   /* 유휴 상태에서 소비한 타이머 틱 수. */
@@ -427,28 +436,30 @@ void thread_yield(void)
 	intr_set_level(old_level);
 }
 
-/* 현재 스레드의 priority를 NEW_PRIORITY로 설정한다. */
-
-// 현재 스레드가 priority를 낮췄을 때,
-// READY 상태의 더 높은 우선순위 스레드에게 바로 CPU를 양보하도록 한다.
+/* 현재 스레드의 기본 우선순위를 NEW_PRIORITY로 바꾼다.
+   donation을 받고 있다면 유효 우선순위는 남아 있는 donations까지 반영해 다시 계산한다.
+   변경 후 READY 상태의 더 높은 priority 스레드가 있으면 즉시 CPU를 양보한다. */
 void thread_set_priority(int new_priority)
 {
+	/* priority를 바꿀 대상은 현재 실행 중인 thread다. */
 	struct thread *curr = thread_current();
 
-	// 현재 스레드의 우선순위를 새 값으로 갱신한다.
+	/* 사용자가 설정한 priority는 donation과 분리해 base_priority에 저장한다. */
 	curr->base_priority = new_priority;
+
+	/* base_priority 변경 후 남아 있는 donation까지 반영해 유효 우선순위를 다시 계산한다. */
 	refresh_priority(curr);
 	
-
-	// ready_list는 이미 우선순위 순서로 정렬되어 있다.
-	// 따라서 맨 앞 원소가 READY 상태 스레드 중 가장 높은 우선순위를 가진다.
+	/* READY 상태인 thread가 하나라도 있으면 선점 필요 여부를 확인한다. */
 	if (!list_empty(&ready_list))
 	{
+		/* ready_list는 priority 순서이므로 front가 현재 가장 높은 READY thread다. */
 		struct thread *front = list_entry(list_front(&ready_list), struct thread, elem);
 
-		// 현재 스레드보다 더 높은 우선순위의 READY 스레드가 있으면 CPU를 양보한다.
+		/* 현재 thread보다 더 높은 priority의 READY thread가 있으면 즉시 CPU를 양보한다. */
 		if (front->priority > curr->priority)
 		{
+			/* scheduler가 더 높은 priority thread를 실행할 수 있도록 현재 thread를 ready_list로 보낸다. */
 			thread_yield();
 		}
 	}
@@ -546,11 +557,17 @@ init_thread(struct thread *t, const char *name, int priority)
 	strlcpy(t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
 	t->priority = priority;
-	/* 여기부터 */
+	/* donation을 반영하기 전의 원래 priority와 donation 추적 상태를 초기화한다. */
+
+	/* thread 생성 시점의 priority를 donation이 없는 기본 priority로 저장한다. */
 	t->base_priority = priority;
+
+	/* 새 thread는 아직 어떤 lock도 기다리지 않으므로 wait_lock을 비워 둔다. */
 	t->wait_lock = NULL;
+
+	/* 새 thread는 아직 donation을 받은 적이 없으므로 donations 리스트를 빈 리스트로 시작한다. */
 	list_init(&t->donations);
-	/* 여기까지 추가 */ 
+
 	t->magic = THREAD_MAGIC;
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -90,7 +90,7 @@ void refresh_priority(struct thread *t)
 // 우선순위 기부 함수. donor가 receiver에게 priority를 기부한다.
 void donate_priority (struct thread *donor, struct thread *receiver) {
 	
-	// donor와 receiver가 유효한 스레드인지 확인한다.
+	// donor와 receiver가 유효한 스레드인지 확인한다. -> 이미 호출 시에 확인이 됐는데 안전을 위해 다시 체크?
 	if (donor == NULL || receiver == NULL ) {
 		return;
 	}
@@ -100,10 +100,24 @@ void donate_priority (struct thread *donor, struct thread *receiver) {
 
 	// donation 추가 후 receiver의 effective priority를 다시 계산한다.
 	refresh_priority(receiver);
-	// donor의 우선순위가 receiver보다 높으면, donor의 우선순위를 receiver에 적용한다.
-	// if (donor->priority > receiver->priority) {
-	// 	receiver->priority = donor->priority;
-	// }
+	
+	// 기다리고 있는 lock이 있고, 그 lock을 들고 있는 thread가 있으면 계속 올라간다.
+	// 2. 이게 donate_priority를 한 번 하고 while문을 도는 거기 때문에, 
+	// 내부적으로 연쇄작용이 일어나는 건 donate_priority 안에서 일어나는 게 맞는 거 같다.
+	// 코드 책임 관점에서 보았을 땐... 그런 거 같긴 한데... 뭐가 더 나을까...
+	while (receiver->wait_lock != NULL && receiver->wait_lock->holder != NULL) {
+		// holder가 또 기다리고 있는 lock의 holder로 이동한다.
+		receiver = receiver->wait_lock->holder;
+				
+		// 현재 thread의 priority가 더 높으면 위쪽 holder의 effective priority를 끌어올린다.
+		// 여기서는 같은 donation_elem을 여러 리스트에 넣지 않고 값만 전파한다.
+		if(donor->priority > receiver->priority) {
+			receiver->priority = donor->priority;
+		}
+		else {
+			break;
+		}
+	}
 }
 
 // lock이 해제될 때, 해당 lock에 대해 기부된 우선순위를 제거한다.


### PR DESCRIPTION
## 작업 내용

- Priority donation 구현을 위해 thread 구조체 멤버로 `base_priority`, `donations`, `donation_elem`, `wait_lock`을 추가했습니다.
- Priority donation 구현을 위해 3개의 helper 함수로 `donate_priority()`, `refresh_priority()`, `remove_donation()`을 추가했습니다. 
- `lock_acquire()`에서 현재 스레드가 더 높은 priority를 가지는 경우 lock holder에게 priority를 donation하도록 수정했습니다.
- `donate_priority()`에서 직접 donation을 등록하고, lock holder chain을 따라 nested donation이 전파되도록 구현했습니다.
- `lock_release()`에서 해당 lock 때문에 받은 donation만 제거하고, 남은 donation과 base priority를 기준으로 priority를 복구하도록 수정했습니다.
- `thread_set_priority()`가 donation 상태를 고려해 base priority와 effective priority를 분리해서 처리하도록 수정했습니다.
- donation 관련 함수와 수정 라인에 한글 주석을 추가했습니다.

## 목표 테스트

- [x] `make tests/threads/priority-donate-one.result`
- [x] `make tests/threads/priority-donate-multiple.result`
- [x] `make tests/threads/priority-donate-multiple2.result`
- [x] `make tests/threads/priority-donate-nest.result`
- [x] `make tests/threads/priority-donate-chain.result`
- [x] `make tests/threads/priority-donate-sema.result`
- [x] `make tests/threads/priority-donate-lower.result`

## 구현 전 의사코드

- lock을 획득하려는 thread는 자신이 기다리는 lock을 `wait_lock`에 기록한다.
- lock holder가 있고 현재 thread의 priority가 더 높으면 holder에게 priority를 donation한다.
- donation을 받은 holder가 또 다른 lock을 기다리고 있으면 holder chain을 따라 priority를 전파하되, 우선순위 비교를 하며 전파한다.
- lock을 해제할 때는 해당 lock 때문에 받은 donation만 제거한다.
- donation 제거 후 `base_priority`와 남은 donations를 기준으로 effective priority를 다시 계산한다.

## 유지해야 할 invariant

- `priority`는 donation이 반영된 effective priority입니다.
- `base_priority`는 donation이 제거되면 돌아가야 하는 원래 priority입니다.
- `donations`에는 현재 thread에게 priority를 기부한 donor thread들이 들어갑니다.
- `wait_lock`은 현재 thread가 기다리는 lock을 가리키며, lock 획득 후 반드시 `NULL`로 초기화되어야 합니다.
- 같은 `donation_elem`은 여러 donations 리스트에 동시에 들어갈 수 없습니다. (여러 lock을 가지고 있는건 가능하지만, 여러 lock을 동시에 기다리는건 불가함)
- lock release 시 `donor->wait_lock == lock`인 donation만 제거해야 합니다. (여러 스레드 가능)
- donation으로 blocked thread의 priority가 바뀔 수 있으므로, waiters를 깨우기 전 priority 기준 재정렬이 필요합니다.

## 테스트 결과
```bash
cd pintos/threads/build
make tests/threads/priority-donate-one.result
make tests/threads/priority-donate-multiple.result
make tests/threads/priority-donate-multiple2.result
make tests/threads/priority-donate-lower.result
make tests/threads/priority-donate-nest.result
make tests/threads/priority-donate-chain.result
make tests/threads/priority-donate-sema.result
```

```text
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-lower
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-chain
pass tests/threads/priority-donate-sema
```

## 학습 메모
- 구현 기록은 docs branch의 docs/p1/p1-donation의 implementation log를 확인하면 됩니다.
- debug 기록은 같은 경로의 debug notes를 확인하면 됩니다.

## 체크리스트
- [x] build 성공
- [x] 목표 테스트 통과
- [x] 관련 회귀 테스트 확인
- [x]  donation 관련 주석 추가
- [x] 관련 priority scheduling 회귀 테스트 확인