### PR TITLE
refactor(project1): Refactoring based on Codex PR Review

### DIFF
--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -358,7 +358,9 @@ void cond_signal(struct condition *cond, struct lock *lock UNUSED)
 	ASSERT(lock_held_by_current_thread(lock));
 
 	if (!list_empty(&cond->waiters))
-	{
+	{	
+		/* donation으로 인해 리스트 정렬이 바뀌었을 수 있기에, pop_front 전에 sort */
+		list_sort(&cond->waiters, semaphore_priority_compare, NULL);
 		struct semaphore_elem *waiter = list_entry(list_pop_front(&cond->waiters),
 												   struct semaphore_elem, elem);
 		sema_up(&waiter->semaphore);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -249,6 +249,8 @@ void lock_release(struct lock *lock)
 	/* 현재 thread가 실제로 들고 있는 lock만 해제할 수 있다. */
 	ASSERT(lock_held_by_current_thread(lock));
 
+	/* remove_donation() 부터 sema_up()이 끝날 때까지 인터럽트 비활성화를 해주어야 한다. */
+	enum intr_level old_level = intr_disable();
 	/* 이 lock 때문에 받은 donation만 제거한 뒤,
 	   남아 있는 donation과 base priority를 기준으로 유효 우선순위를 다시 계산한다. */
 	remove_donation (lock);
@@ -261,6 +263,9 @@ void lock_release(struct lock *lock)
 
 	/* lock을 기다리던 thread 중 하나를 깨워 lock 획득을 다시 시도하게 한다. */
 	sema_up (&lock->semaphore);
+
+	/* 인터럽트 다시 활성화 */
+	intr_set_level(old_level);
 }
 
 /* 현재 thread가 LOCK을 가지고 있으면 true, 아니면 false를 반환한다.

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -203,12 +203,10 @@ void lock_acquire(struct lock *lock)
 
 	/* lock이 이미 점유되어 있고 현재 스레드가 holder보다 높을 때만 donation을 시작한다.
 	   보유자 체인으로의 추가 전파는 donate_priority()가 담당한다. */
+	/* lock waiter는 우선적으로 lock holder의 donations에 있어야 도네이션 전파 시 문제가 없다. */
 	if (holder != NULL) {
-		/* 현재 thread의 priority가 더 높을 때만 holder의 priority를 끌어올릴 필요가 있다. */
-		if (holder->priority < curr->priority) {
 			/* 현재 thread가 lock holder에게 priority를 기부하고, 필요하면 chain 위로 전파한다. */
 			donate_priority (curr, holder);
-		}
 	}
 
 	/* semaphore가 열릴 때까지 대기한다. 깨어나 lock을 얻으면 대기 상태를 해제한다. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -24,6 +24,9 @@
    이 값은 수정하지 않는다. */
 #define THREAD_BASIC 0xd42df210
 
+/* 우선순위 기부 전파 제한 깊이 (KAIST Gitbook 추천 숫자) */
+#define DONATION_DEPTH_LIMIT 8
+
 /* THREAD_READY 상태의 스레드 목록.
    실행할 준비는 되었지만 아직 실제로 실행 중이지 않은 스레드들이 들어간다. */
 static struct list ready_list;
@@ -99,9 +102,10 @@ void refresh_priority(struct thread *t)
    RECEIVER가 다른 lock을 기다리고 있으면 lock 보유자 체인을 따라 priority를 위로 전파한다. */
 void donate_priority (struct thread *donor, struct thread *receiver) {
 	/* 잘못된 인자가 들어오면 donation 리스트를 건드리지 않고 종료한다. */
-	if (donor == NULL || receiver == NULL) {
-		return;
-	}
+	ASSERT(donor != NULL);
+	ASSERT(receiver != NULL);
+
+	int depth = 0;
 
 	/* 현재 기부자가 직접 기다리는 lock의 보유자에게만 donation_elem을 연결한다.
 	   같은 donation_elem을 여러 donations 리스트에 동시에 넣을 수 없기 때문이다. */
@@ -109,13 +113,15 @@ void donate_priority (struct thread *donor, struct thread *receiver) {
 
 	/* 직접 donation을 받은 receiver의 유효 우선순위를 즉시 다시 계산한다. */
 	refresh_priority(receiver);
-	
+
 	/* RECEIVER가 다시 다른 lock을 기다리는 중이면 중첩 기부를 전파한다.
 	   위쪽 보유자들은 직접 donation 리스트에 넣지 않고 유효 우선순위만 끌어올린다. */
-	while (receiver->wait_lock != NULL && receiver->wait_lock->holder != NULL) {
+	while (receiver->wait_lock != NULL &&
+				 receiver->wait_lock->holder != NULL &&
+				 depth < DONATION_DEPTH_LIMIT) {
 		/* receiver가 기다리는 lock의 holder로 이동해 다음 전파 대상을 잡는다. */
 		receiver = receiver->wait_lock->holder;
-				
+		depth++;
 		/* donor priority가 위쪽 holder보다 높을 때만 priority inversion을 완화할 필요가 있다. */
 		if (donor->priority > receiver->priority) {
 			/* donation_elem을 추가로 연결하지 않고 유효 우선순위 값만 위로 전파한다. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -584,10 +584,14 @@ init_thread(struct thread *t, const char *name, int priority)
 static struct thread *
 next_thread_to_run(void)
 {
-	if (list_empty(&ready_list))
+	if (list_empty(&ready_list)) {
 		return idle_thread;
-	else
+	}
+	else {
+		/* ready_list에 있는 lock holder인 스레드가 우선순위를 기부 받아, 삽입 시 정렬 순서와 다를 수 있으므로 재정렬 필요. */
+		list_sort(&ready_list, thread_priority_compare, NULL);
 		return list_entry(list_pop_front(&ready_list), struct thread, elem);
+	}
 }
 
 /* iretq를 사용해 스레드를 시작한다. */


### PR DESCRIPTION
## 작업 요약

- Priority Donation 구현 이후 발견된 scheduling edge case를 보완했습니다.
- `donate_priority()`에 donation chain depth limit을 추가하고, 잘못된 인자에 대해 `ASSERT`로 invariant를 명확히 했습니다.
- `lock_acquire()`에서 현재 thread와 lock holder의 priority를 비교한 뒤 donation 여부를 결정하던 조건을 제거했습니다.
- lock을 기다리기 시작한 thread는 priority 크기와 관계없이 holder의 `donations` 리스트에 등록되도록 수정했습니다.
- READY 상태의 lock holder가 donation을 받은 뒤 `ready_list` 정렬이 stale해지는 문제를 막기 위해 `next_thread_to_run()`에서 선택 직전 재정렬하도록 수정했습니다.
- `lock_release()`에서 donation 제거, priority 복구, holder 해제, waiter wake-up 사이에 timer preemption이 끼어들지 않도록 interrupt-off critical section으로 묶었습니다.
- `cond_signal()`에서 condition waiters를 깨우기 직전에 다시 정렬해, donation 등으로 바뀐 최신 priority를 반영하도록 수정했습니다.

## 목표 테스트

- [x] `make tests/threads/priority-donate-one.result`
- [x] `make tests/threads/priority-donate-multiple.result`
- [x] `make tests/threads/priority-donate-multiple2.result`
- [x] `make tests/threads/priority-donate-lower.result`
- [x] `make tests/threads/priority-donate-nest.result`
- [x] `make tests/threads/priority-donate-chain.result`
- [x] `make tests/threads/priority-donate-sema.result`
- [x] `make tests/threads/priority-sema.result`
- [x] `make tests/threads/priority-condvar.result`

## 구현 전 의사코드

- lock 획득에 실패해 대기하게 되는 thread는 priority 크기와 관계없이 lock holder의 `donations` 리스트에 등록한다.
- `refresh_priority()`가 base priority와 현재 donations 중 최댓값을 기준으로 effective priority를 계산한다.
- donation 전파는 직접 lock holder에게 donor를 기록하고, holder chain은 제한 깊이 안에서 effective priority를 전파한다.
- scheduler가 다음 thread를 고르기 직전에 `ready_list`를 최신 effective priority 기준으로 다시 정렬한다.
- lock release 중 donation 제거부터 waiter wake-up까지는 하나의 atomic 구간으로 처리한다.
- condition variable signal 시점에는 waiters의 priority가 바뀌었을 수 있으므로 pop 직전에 재정렬한다.

## 유지해야 할 invariant

- `thread->priority`는 donation이 반영된 effective priority다.
- `thread->base_priority`는 donation을 제외한 원래 priority다.
- `donations` 리스트에는 `thread.elem`이 아니라 `donation_elem`을 사용한다.
- 하나의 `list_elem`은 동시에 두 리스트에 들어가지 않는다.
- 어떤 thread가 lock을 기다리고 있다면, 그 lock holder의 `donations` 리스트에는 해당 thread가 등록되어 있어야 한다.
- lock release 시 `donor->wait_lock == lock`인 donation만 제거한다.
- READY thread의 priority가 donation으로 변경 가능하니, scheduler는 최신 priority 기준으로 thread를 선택해야 한다.

## 구현 내용

- `lock_acquire()`
  - 기존에는 현재 thread의 priority가 holder보다 높을 때만 `donate_priority()`를 호출했습니다.
  - 이제 lock holder가 존재하면 priority 크기와 관계없이 `donate_priority()`를 호출합니다.
  - 이 변경으로 “처음에는 priority가 낮아 donation 대상이 아니었지만, 나중에 nested donation으로 priority가 올라가는 waiter”도 holder의 `donations` 리스트에 남게 됩니다.

- `donate_priority()`
  - NULL 인자는 `ASSERT`로 검증하도록 변경했습니다.
  - donation chain 전파 깊이를 `DONATION_DEPTH_LIMIT`으로 제한했습니다.
  - 직접 receiver에는 donation 관계를 기록하고, 상위 holder chain에는 effective priority 값을 전파합니다.
  - 실제 priority 반영 여부는 `refresh_priority()`가 base priority와 donations의 최댓값을 기준으로 결정합니다.

- `next_thread_to_run()`
  - READY 상태의 lock holder가 donation을 받아 기존 삽입 순서와 실제 priority가 달라질 수 있으므로, `list_pop_front()` 전에 `ready_list`를 재정렬합니다.

- `lock_release()`
  - `remove_donation()`, `refresh_priority()`, `lock->holder = NULL`, `sema_up()`을 interrupt-off 구간으로 묶었습니다.
  - donation 제거 후 waiter가 깨기 전 timer preemption이 발생해 medium priority thread가 먼저 실행되는 window를 줄였습니다.

- `cond_signal()`
  - condition waiters를 pop하기 직전에 `semaphore_priority_compare` 기준으로 재정렬합니다.
  - waiters에 들어간 이후 donation으로 priority가 바뀐 경우를 반영합니다.

## 테스트 결과

- 회귀 테스트 ALL PASS

## 위험 요소

- `next_thread_to_run()`에서 매번 `list_sort()`를 호출하므로 ready list 크기에 따라 비용이 증가할 수 있습니다.
- `lock_release()`의 interrupt-off 구간이 기존보다 길어졌습니다.
- priority가 낮은 waiter도 holder의 `donations` 리스트에 등록되므로, `refresh_priority()`가 항상 base priority와 donations 최댓값을 기준으로 계산해야 합니다.
- 같은 thread의 `donation_elem`이 중복 삽입되지 않도록, 한 thread가 동시에 하나의 lock만 기다린다는 invariant에 의존합니다.

## 학습 메모

- lock holder는 lock을 가지고 있어도 running 상태가 아닐 수 있고, READY 상태로 `ready_list`에 있을 수 있습니다.
- donation으로 READY thread의 priority가 바뀌면 삽입 시점의 ready list 정렬만으로는 충분하지 않습니다.
- `sema_up()` 내부의 interrupt disable은 공용 semaphore 자료구조 보호를 위한 것이므로, caller가 interrupt를 끈 상태로 호출해도 제거하면 안 됩니다.
- condition waiters도 삽입 이후 priority가 바뀔 수 있으므로, 깨우는 시점의 최신 priority 기준 선택이 필요합니다.
- `donations` 리스트는 “나보다 높은 priority를 준 thread 목록”이 아니라, 더 정확히는 “내가 가진 lock을 기다리는 직접 waiter 목록”으로 유지하는 쪽이 nested donation에 안전합니다.

## 체크리스트

- [x] build 성공
- [x] 회귀 테스트 통과
