### PR TITLE
refactor(Project 1) :  Refactoring project 1

### DIFF
--- a/pintos/docs/gh-pr-review-skill-package/MANUAL.md
+++ b/pintos/docs/gh-pr-review-skill-package/MANUAL.md
@@ -1,0 +1,190 @@
+# gh-pr-review 배포 및 사용 매뉴얼
+
+`gh-pr-review`는 현재 브랜치의 GitHub PR을 리뷰하는 Codex 스킬입니다. 로컬 git 상태 점검, pull 여부 확인, PR 컨텍스트 수집, diff 리뷰, unresolved review comments 확인 흐름을 처리합니다. Pintos repo 또는 Pintos 경로가 감지되면 KAIST CS330 64-bit Pintos 리뷰 모드로 전환됩니다.
+
+## 패키지 구성
+
+```text
+gh-pr-review-skill-package/
+├── gh-pr-review/
+│   ├── SKILL.md
+│   ├── agents/
+│   │   └── openai.yaml
+│   └── references/
+│       ├── general-checklist.md
+│       ├── pintos-checklist.md
+│       └── review-workflow.md
+├── install.sh
+├── install.ps1
+└── MANUAL.md
+```
+
+`gh-pr-review/` 폴더가 실제 Codex skill입니다. `MANUAL.md`, `install.sh`, `install.ps1`은 배포 편의를 위한 바깥 파일이며 skill 내부에는 포함되지 않습니다.
+
+## 설치
+
+압축을 푼 뒤 패키지 루트에서 운영체제에 맞는 설치 스크립트를 실행합니다.
+
+macOS/Linux:
+
+```bash
+./install.sh
+```
+
+Windows PowerShell:
+
+```powershell
+.\install.ps1
+```
+
+PowerShell 실행 정책 때문에 막히면 아래처럼 실행할 수 있습니다.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+설치 위치는 다음 규칙을 따릅니다.
+
+```bash
+${CODEX_HOME:-$HOME/.codex}/skills/gh-pr-review
+```
+
+Windows에서는 `$env:CODEX_HOME`이 있으면 그 아래 `skills\gh-pr-review`에 설치하고, 없으면 `$HOME\.codex\skills\gh-pr-review`에 설치합니다.
+
+이미 같은 이름의 스킬이 있으면 `gh-pr-review.backup.YYYYMMDDHHMMSS` 형태로 백업한 뒤 새 버전을 설치합니다.
+
+수동 설치를 원하면 아래처럼 복사해도 됩니다.
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+cp -R gh-pr-review "${CODEX_HOME:-$HOME/.codex}/skills/gh-pr-review"
+```
+
+설치 후 새 Codex thread를 열면 스킬 목록에 반영되는 것이 가장 확실합니다.
+
+## 사전 조건
+
+- `gh` GitHub CLI 설치 및 인증 완료
+- 현재 작업 디렉터리가 git repository
+- 현재 브랜치에 연결된 GitHub PR이 있음
+- PR 리뷰를 위해 GitHub repo 접근 권한이 있음
+
+## 기본 사용법
+
+가장 일반적인 호출:
+
+```text
+현재 브랜치에서 $gh-pr-review 를 사용해 pull 여부를 먼저 확인한 뒤 PR을 리뷰해줘.
+```
+
+pull 없이 현재 로컬 상태 기준으로만 리뷰:
+
+```text
+현재 브랜치에서 $gh-pr-review 를 사용해줘. pull은 하지 말고 현재 로컬 상태 기준으로 PR을 리뷰해줘.
+```
+
+Pintos 특화 리뷰:
+
+```text
+현재 브랜치에서 $gh-pr-review 를 사용해 PR을 리뷰해줘. Pintos 모드가 감지되면 phase와 grading test 영향까지 같이 봐줘.
+```
+
+unresolved review comments 확인:
+
+```text
+현재 브랜치에서 $gh-pr-review 를 사용해서 unresolved review comments를 확인하고, 어떤 코멘트에 어떻게 대응해야 할지 정리해줘.
+```
+
+## GitHub PR 코멘트 게시
+
+기본 리뷰는 GitHub에 아무것도 쓰지 않습니다. PR에 댓글을 남기려면 게시 의도를 명시해야 합니다.
+
+게시 전 초안 확인:
+
+```text
+현재 브랜치에서 $gh-pr-review 로 리뷰한 뒤, GitHub PR에 올릴 리뷰 댓글 초안을 먼저 보여줘. 내가 확인하면 게시해줘.
+```
+
+일반 PR 코멘트로 게시:
+
+```text
+현재 브랜치에서 $gh-pr-review 로 리뷰하고, 발견한 주요 findings를 GitHub PR에 review comment로 게시해줘.
+```
+
+라인별 inline comment:
+
+```text
+현재 브랜치에서 $gh-pr-review 로 리뷰하고, line anchor가 정확한 findings만 GitHub inline review comment로 달아줘. 파일 전반 의견은 일반 PR 코멘트로 남겨줘.
+```
+
+GitHub에 게시되는 코멘트에는 Codex 내부 작업 안내, 예를 들어 `"고쳐줘"`라고 말하라는 문구를 넣지 않도록 되어 있습니다.
+
+## 동작 요약
+
+1. 로컬 상태 확인: clean, dirty, detached HEAD, upstream 여부
+2. pull 여부 확인: 자동 pull 금지, 사용자가 허용하면 `git pull --ff-only`
+3. PR 식별: `gh pr view`
+4. PR 메타데이터와 변경 파일 수집
+5. Pintos 모드 및 phase 자동 감지
+6. 일반 또는 Pintos 체크리스트로 diff 리뷰
+7. findings-first 형식으로 결과 출력
+8. 명시 요청이 있을 때만 GitHub write action 수행
+
+## 안전 정책
+
+- 코드 수정은 하지 않습니다.
+- PR 댓글 작성, review submit, thread resolve는 명시 요청 없이는 하지 않습니다.
+- dirty 상태에서는 먼저 멈추고 선택지를 제시합니다.
+- `git pull --ff-only` 외 merge 전략은 자동 사용하지 않습니다.
+- PR이 없으면 자동 생성하지 않습니다.
+
+## Pintos 모드
+
+다음 중 하나라도 감지되면 Pintos 모드가 켜집니다.
+
+- repo 이름 또는 remote URL에 `pintos` 포함
+- 변경 파일 경로에 `threads/`, `userprog/`, `vm/`, `filesys/` 포함
+- `pintos/threads/`, `pintos/userprog/`, `pintos/vm/`, `pintos/filesys/` 같은 중간 경로 포함
+- `Makefile.build` 또는 Pintos 유틸 경로 존재
+- README/docs에 `KAIST CS330`, `Pintos`, `64-bit Pintos` 언급
+
+phase 추정:
+
+- `threads/` -> Phase 1
+- `userprog/` -> Phase 2
+- `vm/` -> Phase 3
+- `filesys/` -> Phase 4
+
+## 검증
+
+스킬 구조 검증:
+
+```bash
+python3 /path/to/skill-creator/scripts/quick_validate.py gh-pr-review
+```
+
+확인할 핵심 항목:
+
+- `SKILL.md` frontmatter에 `name`, `description` 존재
+- `agents/openai.yaml`의 `default_prompt`에 `$gh-pr-review` 포함
+- `policy.allow_implicit_invocation: false`
+- `references/`에 세 체크리스트 파일 존재
+
+## 문제 해결
+
+스킬이 호출되지 않는 경우:
+
+- `$gh-pr-review`처럼 `$` 포함해 명시 호출했는지 확인합니다.
+- 설치 후 새 Codex thread를 열어 다시 시도합니다.
+- 설치 경로가 `${CODEX_HOME:-$HOME/.codex}/skills/gh-pr-review`인지 확인합니다.
+
+PR을 못 찾는 경우:
+
+- 현재 브랜치에 PR이 연결되어 있는지 확인합니다.
+- `gh pr view`가 현재 repo에서 동작하는지 확인합니다.
+- `gh auth status`로 인증 상태를 확인합니다.
+
+GitHub에 댓글이 안 달리는 경우:
+
+- 프롬프트에 `게시해줘`, `PR 댓글로 남겨줘`, `inline comment로 달아줘`처럼 write action을 명시했는지 확인합니다.
+- repo 권한과 `gh` 인증 상태를 확인합니다.

--- a/pintos/docs/gh-pr-review-skill-package/gh-pr-review/SKILL.md
+++ b/pintos/docs/gh-pr-review-skill-package/gh-pr-review/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: gh-pr-review
+description: 명시 호출 시 현재 브랜치 GitHub PR을 로컬 상태 점검, pull 여부 확인, 컨텍스트 수집, diff 리뷰, unresolved review comments 대응 흐름으로 처리하는 리뷰 전용 스킬입니다. Pintos repo/파일 패턴을 감지하면 KAIST CS330 64-bit Pintos 특화 리뷰를 적용합니다.
+---
+
+# gh-pr-review
+
+Use this skill only when the user explicitly invokes `$gh-pr-review` or directly asks to use the `gh-pr-review` skill. Default response language is Korean; keep code identifiers, commands, file paths, and error messages in their original English.
+
+This is a review-only skill. Do not edit code, create commits, post PR comments, submit reviews, or resolve review threads unless the user explicitly asks for that write action. If the user says "고쳐줘" or otherwise asks for implementation, leave review mode and handle the code-change task separately.
+
+## Required References
+
+- Always read `references/review-workflow.md` before starting a PR review.
+- Read `references/general-checklist.md` for normal repositories and as the base checklist for every review.
+- If Pintos mode is detected by `references/review-workflow.md`, also read `references/pintos-checklist.md` and apply it in addition to the general checklist.
+- For unresolved review comments, follow the routing and fallback rules in `references/review-workflow.md`; use the `gh-address-comments` flow when available.
+
+## Operating Rules
+
+1. Start by checking local git state. If the branch is dirty, detached, or ambiguous, pause and ask the user to choose from the documented options.
+2. Ask before running `git pull --ff-only`. Never auto-merge or auto-rebase after a pull failure.
+3. Identify the current branch's PR with `gh`. If there is no PR, report that and stop; never create a draft PR automatically.
+4. Gather PR metadata, changed files, intent, linked issue context, and relevant base-branch code before reviewing the diff.
+5. Detect Pintos mode and phase before producing findings. If active, state the mode in the output header, for example `(Pintos Phase 1: threads 모드)`.
+6. Report review results findings-first. Prefer real bugs, regressions, memory safety, synchronization, API contract, data integrity, and missing tests over style preferences.
+7. If there are no substantive issues, say `주요 이슈 없음` clearly and mention only remaining test or verification risk.
+
+## Output Shape
+
+Use Korean explanations with English code tokens. Findings should include priority, confidence, file and line anchor when possible, evidence, impact, and suggested fix. End with a short `다음 단계` section that states whether High findings should block merge and what tests are likely affected. When preparing text to post on GitHub, omit internal workflow guidance such as asking the user to say "고쳐줘" for code changes.

--- a/pintos/docs/gh-pr-review-skill-package/gh-pr-review/agents/openai.yaml
+++ b/pintos/docs/gh-pr-review-skill-package/gh-pr-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "GitHub PR Review"
+  short_description: "Pull 확인 후 현재 GitHub PR 리뷰"
+  default_prompt: "현재 브랜치에서 $gh-pr-review 를 사용해 pull 여부를 먼저 확인한 뒤 PR을 리뷰해줘."
+
+policy:
+  allow_implicit_invocation: false

--- a/pintos/docs/gh-pr-review-skill-package/gh-pr-review/references/general-checklist.md
+++ b/pintos/docs/gh-pr-review-skill-package/gh-pr-review/references/general-checklist.md
@@ -1,0 +1,29 @@
+# General PR Review Checklist
+
+Use this checklist for all repositories. In Pintos mode, apply this first and then layer on `pintos-checklist.md`.
+
+## Core Review Dimensions
+
+- Correctness: logic errors, off-by-one mistakes, null/undefined handling, boundary conditions, invalid assumptions.
+- Regression risk: changed existing behavior, breaking changes, semantic compatibility, unexpected side effects.
+- Error handling: missing try/catch or cleanup, swallowed errors, partial failure behavior, retry/idempotency issues.
+- Concurrency: race conditions, lock ordering, transaction boundaries, shared mutable state, async cancellation.
+- Security: input validation, injection, authorization, sensitive data exposure, unsafe logging.
+- Data integrity: migration safety, rollback path, data loss risk, consistency between models and schema.
+- Performance: N+1 work, algorithmic complexity, avoidable allocation, leaks, hot-path regressions.
+- Test quality: coverage for new behavior, edge cases, error paths, precise assertions, appropriate mocks.
+- API contract: public interface changes, versioning, documentation, backward compatibility.
+- Observability: useful logs, metrics, traces, auditability for new failure modes.
+
+## Diff-Adjacent Checks
+
+- Search other callers of changed functions/classes with `rg`.
+- For interface changes, verify all required call sites and docs moved together.
+- For new dependencies, check manifest and lockfile consistency.
+- For migrations, verify model/schema/test fixtures match the migration.
+- For config changes, check environment-specific behavior and safe defaults.
+- For tests-only PRs, review whether assertions genuinely catch the intended behavior and avoid overfitting.
+
+## Review Judgment
+
+Prioritize user-visible bugs, correctness, safety, and missing verification. Mention style only when it creates real maintainability or defect risk. If evidence is incomplete, mark confidence as `low` and explain what should be checked.

--- a/pintos/docs/gh-pr-review-skill-package/gh-pr-review/references/pintos-checklist.md
+++ b/pintos/docs/gh-pr-review-skill-package/gh-pr-review/references/pintos-checklist.md
@@ -1,0 +1,95 @@
+# Pintos Review Checklist
+
+Use this only when Pintos mode is active. All examples must be in C. Do not use Java, Python, or unrelated language analogies. Explain concurrency with Pintos primitives such as `lock_acquire`, `lock_release`, `sema_down`, `sema_up`, `cond_wait`, `intr_disable`, and `thread_block`. Keep the tone educational: explain why the pattern is risky, not just that it is wrong. When possible, mention likely `make check` or grading-test impact.
+
+KAIST CS330 uses 64-bit Pintos. Watch for stale 32-bit assumptions in pointer sizes, register widths, syscall argument extraction, stack alignment, and trap frame fields.
+
+## Common Checks For All Phases
+
+Synchronization:
+
+- `lock_acquire` and `lock_release` are paired on every return path.
+- Locks are not acquired from interrupt context; check `intr_context()` where relevant.
+- Code does not call `thread_block()` directly while holding a lock unless the surrounding primitive requires and proves it safe.
+- `sema_down` and `sema_up` are paired and cannot lose wakeups.
+- `cond_wait` is called only while holding the associated lock and rechecks the condition after wakeup when needed.
+- Interrupt state is restored correctly after `intr_disable()`.
+
+Memory safety:
+
+- `palloc_get_page`/`palloc_free_page` and `malloc`/`free` are paired.
+- No use-after-free or dangling pointer remains after cleanup.
+- Objects embedded in Pintos lists are removed before being freed.
+- Kernel stack stays within 4 KB; avoid large local arrays or structs.
+- Every allocation failure path cleans up earlier resources.
+
+Data structures:
+
+- `list_entry(elem, struct type, member)` uses the correct member.
+- `list_remove` is not followed by accidental reuse of stale links.
+- `ready_list`, `sleep_list`, frame lists, and wait lists preserve their intended ordering.
+- Shared lists are protected by the intended lock or interrupt discipline.
+
+Testing and grading:
+
+- Review likely `make check` impact by phase.
+- Be suspicious of fixes that hide races with sleeps or timing assumptions.
+- Distinguish a general implementation from code tailored only to one visible test.
+
+KAIST 64-bit specifics:
+
+- Syscall arguments should not use stale 32-bit `*(esp + 4)` style extraction.
+- x86-64 syscall arguments come through registers/trap frame fields such as `rax`, `rdi`, `rsi`, `rdx`, `r10`, `r8`, and `r9` depending on the local skeleton.
+- User stack setup should respect 16-byte alignment requirements.
+- Pointer truncation to `int` or `uint32_t` is usually a bug.
+
+## Phase 1: threads
+
+- `thread_yield()` and `thread_block()` are called with the correct interrupt state.
+- Alarm clock implementation does not busy wait.
+- Priority scheduling uses `ready_list` ordering or `list_max` consistently.
+- Priority donation handles nested donation, multiple donors, lock release, and priority restoration.
+- Donation does not recurse indefinitely and respects any project-defined depth cap.
+- MLFQS fixed-point arithmetic uses the correct scale, rounding, and update cadence.
+
+Likely tests: `alarm-*`, `priority-*`, `priority-donate-*`, `mlfqs-*`.
+
+## Phase 2: userprog
+
+- User pointers are validated with `is_user_vaddr`, page table lookup, `get_user`/`put_user`, or a consistent page-fault strategy.
+- Syscall entry validates buffers and strings across page boundaries.
+- Argument passing builds a correctly aligned x86-64 user stack.
+- File descriptor table logic handles invalid descriptors, repeated close, process exit, and synchronization.
+- Parent/child wait and exit state cannot leak or double-free.
+- Open files are closed and denied writes are released on process exit.
+
+Likely tests: `args-*`, `sc-*`, `wait-*`, `exec-*`, `multi-*`, file descriptor tests.
+
+## Phase 3: vm
+
+- Supplemental page table, frame table, swap table, and file-backed page locks have a consistent order.
+- Page fault handler cannot recursively fault forever.
+- Frame eviction pins pages during I/O and avoids evicting unsafe frames.
+- Swap slots are freed exactly once.
+- Lazy loading validates file offsets and read/zero byte counts.
+- `mmap` dirty pages are written back correctly and unmapped pages clean up frames/swap.
+
+Likely tests: `page-*`, `mmap-*`, `swap-*`, `pt-*`, `cow-*` if present.
+
+## Phase 4: filesys
+
+- Buffer cache entries are synchronized per block and with eviction.
+- Dirty cache blocks are flushed at the required times.
+- Inode growth handles direct, indirect, and doubly indirect block allocation consistently.
+- Concurrent inode/file operations cannot corrupt length, deny-write count, or block pointers.
+- Subdirectories handle `.`, `..`, root, removal, and current working directory semantics.
+- Free-map updates remain consistent on partial allocation failure.
+
+Likely tests: `grow-*`, `dir-*`, `syn-*`, `cache-*`, persistence tests.
+
+## Pintos Diff-Adjacent Checks
+
+- If `threads/thread.h`, `threads/synch.h`, or central headers changed, inspect dependent files.
+- If `Makefile.build` changed, verify every new source file is registered once and in the correct phase.
+- If Pintos command options or utilities changed, inspect matching `utils/` behavior.
+- Search existing `tests/` for the changed function or behavior to avoid breaking hidden assumptions.

--- a/pintos/docs/gh-pr-review-skill-package/gh-pr-review/references/review-workflow.md
+++ b/pintos/docs/gh-pr-review-skill-package/gh-pr-review/references/review-workflow.md
@@ -1,0 +1,141 @@
+# Review Workflow
+
+This workflow is mandatory for `$gh-pr-review`. It is intentionally conservative: inspect local state first, ask before pulling, gather context before judging the diff, and never perform GitHub write actions without explicit user request.
+
+## 1. Local State Gate
+
+Run:
+
+```bash
+git status --short --branch
+git branch --show-current
+git rev-parse --abbrev-ref --symbolic-full-name @{u}
+```
+
+Use this decision tree:
+
+```text
+clean + upstream exists
+  -> ask whether to run git pull --ff-only
+     -> if user says pull: run git pull --ff-only
+        -> success: continue
+        -> failure/divergence: ask user to choose rebase attempt, review current state, or stop
+     -> if user says do not pull: continue
+
+dirty staged/unstaged/untracked changes
+  -> stop, summarize status, and ask user to choose stash then pull, review current state only, or stop
+
+detached HEAD
+  -> explain that the PR cannot be identified reliably and stop
+
+no upstream
+  -> explain that pull is skipped and continue with review if a PR can be identified
+```
+
+Only use `git pull --ff-only` in this skill. Do not auto-merge, auto-rebase, or discard local changes.
+
+## 2. PR Identification
+
+Use `gh pr view --json number,title,body,baseRefName,headRefName,url` on the current branch first.
+
+- If exactly one PR is identified, continue.
+- If no PR is found, tell the user and stop. Do not create a PR.
+- If multiple PRs are possible, list open candidates with `gh pr list --head <branch> --json number,title,url,baseRefName,headRefName` and ask the user to choose.
+
+## 3. Required Context Before Diff Review
+
+Before writing findings:
+
+1. Read PR metadata: title, body, base branch, head branch, URL, draft state when available.
+2. Follow linked issue references from the PR body when practical, using `gh issue view` or linked URLs.
+3. Inspect changed files with `gh pr diff <number> --name-only` and estimate impacted domains.
+4. Detect Pintos mode and phase using the rules below.
+5. For modified large functions/classes or public interfaces, inspect the base-branch version and nearby callers with `rg`.
+6. Compare PR intent with actual changes. Treat unrelated behavior changes, hidden refactors, or broad churn as possible scope creep.
+
+Default diff scope is the full PR diff against the base branch, usually `gh pr diff <number>`.
+
+## 4. Pintos Mode Detection
+
+Activate Pintos mode if any of these are true:
+
+- Repository name or remote URL contains `pintos`.
+- Changed paths include phase directories anywhere in the path, such as `threads/`, `userprog/`, `vm/`, `filesys/`, `pintos/threads/`, `pintos/userprog/`, `pintos/vm/`, `pintos/filesys/`, `pintos/include/threads/`, or `pintos/tests/threads/`.
+- `Makefile.build`, Pintos utilities, or Pintos-specific build paths are present.
+- README or docs mention `KAIST CS330`, `Pintos`, or `64-bit Pintos`.
+
+Estimate phases from changed paths. Multiple phases may be active:
+
+- `threads/`, `include/threads/`, `tests/threads/` -> Phase 1: threads
+- `userprog/`, `include/userprog/`, `tests/userprog/` -> Phase 2: userprog
+- `vm/`, `include/vm/`, `tests/vm/` -> Phase 3: vm
+- `filesys/`, `include/filesys/`, `tests/filesys/` -> Phase 4: filesys
+
+When active, include an output header such as:
+
+```text
+(Pintos Phase 1: threads 모드)
+```
+
+For multiple phases, list them all.
+
+## 5. Large Diff Split Gate
+
+Before reviewing, consider asking the user whether to split the review by file or domain if any trigger is met after excluding generated/non-production files:
+
+- Hand-written production code changes are at least 1000 lines.
+- Production file count is at least 15.
+- The PR clearly spans multiple domains, such as backend + frontend + infra.
+
+Exclude generated and low-signal files from the split calculation: `build/`, `dist/`, `out/`, `.next/`, `coverage/`, `node_modules/`, minified assets, generated files, lock files, vendored code, compiled artifacts, and Pintos build outputs.
+
+## 6. Findings-First Format
+
+Prefer Markdown findings because they are easy to share. Use inline `::code-comment{...}` only when there are 5 or fewer findings and every finding has an exact line anchor. If both are suitable, prefer Markdown.
+
+Markdown finding format:
+
+```markdown
+### [High, confidence: high] path/to/file.c:123 - 한 줄 요약
+근거: 어떤 코드/패턴 때문에 문제인지.
+영향: 무엇이 잘못될 수 있는지. Pintos 모드라면 관련 grading test 영향도 포함.
+제안: 어떻게 바꾸면 좋은지.
+```
+
+Confidence levels:
+
+- `high`: diff and surrounding context strongly support the finding.
+- `medium`: likely issue, but one assumption remains.
+- `low`: plausible issue needing confirmation. Use cautious wording such as `확인 필요`.
+
+Priority mapping:
+
+| Priority | General mode | Pintos mode |
+| --- | --- | --- |
+| High | Bugs, regressions, security issues, data loss | Synchronization bugs, memory leaks, undefined behavior, likely grading test failure |
+| Medium | Performance, missing tests, error handling | Inefficiency, partial race risk, duplicated fragile logic |
+| Low | Readability, naming, maintainability | Style, comments, small clarity issues |
+
+Avoid findings for pure taste, quote style, line wrapping, or unrelated refactor preferences.
+
+End every review with:
+
+```markdown
+## 다음 단계
+1. High 항목 N개는 머지 전 반드시 수정 권장
+2. Pintos 모드라면 영향받을 수 있는 grading test 또는 make check 범위
+```
+
+When posting or drafting a GitHub PR comment, do not include internal Codex workflow guidance such as asking the user to say `"고쳐줘"` for a separate code-change task. Keep posted comments focused on review findings, merge risk, and verification.
+
+If no issues are found, say `주요 이슈 없음` and keep the remaining risk section brief.
+
+## 7. Unresolved Review Comments
+
+If the user asks to inspect or respond to unresolved review comments:
+
+1. Prefer the `gh-address-comments` skill/flow when it is available.
+2. Otherwise use GitHub GraphQL review threads. Query `reviewThreads` and group by thread, including `isResolved`, `isOutdated`, path, line anchor, author, body, URL, and diff hunk where available.
+3. As a last resort, use REST `pulls/{number}/comments`. Clearly state that resolved status is unreliable or unknown with this fallback.
+
+Do not post replies, resolve threads, submit reviews, or modify code unless the user explicitly asks for that write action.

--- a/pintos/docs/gh-pr-review-skill-package/install.ps1
+++ b/pintos/docs/gh-pr-review-skill-package/install.ps1
@@ -1,0 +1,33 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$PackageDir = $PSScriptRoot
+$SourceDir = Join-Path $PackageDir "gh-pr-review"
+
+if (-not (Test-Path (Join-Path $SourceDir "SKILL.md") -PathType Leaf)) {
+    Write-Error "Cannot find skill source at $SourceDir"
+    exit 1
+}
+
+if ($env:CODEX_HOME) {
+    $CodexHome = $env:CODEX_HOME
+} else {
+    $CodexHome = Join-Path $HOME ".codex"
+}
+
+$SkillsDir = Join-Path $CodexHome "skills"
+$TargetDir = Join-Path $SkillsDir "gh-pr-review"
+
+New-Item -ItemType Directory -Force -Path $SkillsDir | Out-Null
+
+if (Test-Path $TargetDir) {
+    $Timestamp = Get-Date -Format "yyyyMMddHHmmss"
+    $BackupDir = "$TargetDir.backup.$Timestamp"
+    Move-Item -Path $TargetDir -Destination $BackupDir
+    Write-Host "Backed up existing skill to: $BackupDir"
+}
+
+Copy-Item -Path $SourceDir -Destination $TargetDir -Recurse
+
+Write-Host "Installed gh-pr-review skill to: $TargetDir"
+Write-Host 'Open a new Codex thread, then invoke it with: Use $gh-pr-review to review the current PR.'

--- a/pintos/docs/gh-pr-review-skill-package/install.sh
+++ b/pintos/docs/gh-pr-review-skill-package/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$PACKAGE_DIR/gh-pr-review"
+SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
+TARGET_DIR="$SKILLS_DIR/gh-pr-review"
+
+if [[ ! -f "$SOURCE_DIR/SKILL.md" ]]; then
+  echo "ERROR: Cannot find skill source at $SOURCE_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$SKILLS_DIR"
+
+if [[ -e "$TARGET_DIR" ]]; then
+  BACKUP_DIR="${TARGET_DIR}.backup.$(date +%Y%m%d%H%M%S)"
+  mv "$TARGET_DIR" "$BACKUP_DIR"
+  echo "Backed up existing skill to: $BACKUP_DIR"
+fi
+
+cp -R "$SOURCE_DIR" "$TARGET_DIR"
+
+echo "Installed gh-pr-review skill to: $TARGET_DIR"
+echo "Open a new Codex thread, then invoke it with: 현재 브랜치에서 \$gh-pr-review 를 사용해 pull 여부를 먼저 확인한 뒤 PR을 리뷰해줘."

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -358,7 +358,9 @@ void cond_signal(struct condition *cond, struct lock *lock UNUSED)
 	ASSERT(lock_held_by_current_thread(lock));
 
 	if (!list_empty(&cond->waiters))
-	{
+	{	
+		/* donation으로 인해 리스트 정렬이 바뀌었을 수 있기에, pop_front 전에 sort */
+		list_sort(&cond->waiters, semaphore_priority_compare, NULL);
 		struct semaphore_elem *waiter = list_entry(list_pop_front(&cond->waiters),
 												   struct semaphore_elem, elem);
 		sema_up(&waiter->semaphore);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -249,6 +249,8 @@ void lock_release(struct lock *lock)
 	/* 현재 thread가 실제로 들고 있는 lock만 해제할 수 있다. */
 	ASSERT(lock_held_by_current_thread(lock));
 
+	/* remove_donation() 부터 sema_up()이 끝날 때까지 인터럽트 비활성화를 해주어야 한다. */
+	enum intr_level old_level = intr_disable();
 	/* 이 lock 때문에 받은 donation만 제거한 뒤,
 	   남아 있는 donation과 base priority를 기준으로 유효 우선순위를 다시 계산한다. */
 	remove_donation (lock);
@@ -261,6 +263,9 @@ void lock_release(struct lock *lock)
 
 	/* lock을 기다리던 thread 중 하나를 깨워 lock 획득을 다시 시도하게 한다. */
 	sema_up (&lock->semaphore);
+
+	/* 인터럽트 다시 활성화 */
+	intr_set_level(old_level);
 }
 
 /* 현재 thread가 LOCK을 가지고 있으면 true, 아니면 false를 반환한다.

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -203,12 +203,10 @@ void lock_acquire(struct lock *lock)
 
 	/* lock이 이미 점유되어 있고 현재 스레드가 holder보다 높을 때만 donation을 시작한다.
 	   보유자 체인으로의 추가 전파는 donate_priority()가 담당한다. */
+	/* lock waiter는 우선적으로 lock holder의 donations에 있어야 도네이션 전파 시 문제가 없다. */
 	if (holder != NULL) {
-		/* 현재 thread의 priority가 더 높을 때만 holder의 priority를 끌어올릴 필요가 있다. */
-		if (holder->priority < curr->priority) {
 			/* 현재 thread가 lock holder에게 priority를 기부하고, 필요하면 chain 위로 전파한다. */
 			donate_priority (curr, holder);
-		}
 	}
 
 	/* semaphore가 열릴 때까지 대기한다. 깨어나 lock을 얻으면 대기 상태를 해제한다. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -24,6 +24,9 @@
    이 값은 수정하지 않는다. */
 #define THREAD_BASIC 0xd42df210
 
+/* 우선순위 기부 전파 제한 깊이 (KAIST Gitbook 추천 숫자) */
+#define DONATION_DEPTH_LIMIT 8
+
 /* THREAD_READY 상태의 스레드 목록.
    실행할 준비는 되었지만 아직 실제로 실행 중이지 않은 스레드들이 들어간다. */
 static struct list ready_list;
@@ -99,9 +102,10 @@ void refresh_priority(struct thread *t)
    RECEIVER가 다른 lock을 기다리고 있으면 lock 보유자 체인을 따라 priority를 위로 전파한다. */
 void donate_priority (struct thread *donor, struct thread *receiver) {
 	/* 잘못된 인자가 들어오면 donation 리스트를 건드리지 않고 종료한다. */
-	if (donor == NULL || receiver == NULL) {
-		return;
-	}
+	ASSERT(donor != NULL);
+	ASSERT(receiver != NULL);
+
+	int depth = 0;
 
 	/* 현재 기부자가 직접 기다리는 lock의 보유자에게만 donation_elem을 연결한다.
 	   같은 donation_elem을 여러 donations 리스트에 동시에 넣을 수 없기 때문이다. */
@@ -109,13 +113,15 @@ void donate_priority (struct thread *donor, struct thread *receiver) {
 
 	/* 직접 donation을 받은 receiver의 유효 우선순위를 즉시 다시 계산한다. */
 	refresh_priority(receiver);
-	
+
 	/* RECEIVER가 다시 다른 lock을 기다리는 중이면 중첩 기부를 전파한다.
 	   위쪽 보유자들은 직접 donation 리스트에 넣지 않고 유효 우선순위만 끌어올린다. */
-	while (receiver->wait_lock != NULL && receiver->wait_lock->holder != NULL) {
+	while (receiver->wait_lock != NULL &&
+				 receiver->wait_lock->holder != NULL &&
+				 depth < DONATION_DEPTH_LIMIT) {
 		/* receiver가 기다리는 lock의 holder로 이동해 다음 전파 대상을 잡는다. */
 		receiver = receiver->wait_lock->holder;
-				
+		depth++;
 		/* donor priority가 위쪽 holder보다 높을 때만 priority inversion을 완화할 필요가 있다. */
 		if (donor->priority > receiver->priority) {
 			/* donation_elem을 추가로 연결하지 않고 유효 우선순위 값만 위로 전파한다. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -584,10 +584,14 @@ init_thread(struct thread *t, const char *name, int priority)
 static struct thread *
 next_thread_to_run(void)
 {
-	if (list_empty(&ready_list))
+	if (list_empty(&ready_list)) {
 		return idle_thread;
-	else
+	}
+	else {
+		/* ready_list에 있는 lock holder인 스레드가 우선순위를 기부 받아, 삽입 시 정렬 순서와 다를 수 있으므로 재정렬 필요. */
+		list_sort(&ready_list, thread_priority_compare, NULL);
 		return list_entry(list_pop_front(&ready_list), struct thread, elem);
+	}
 }
 
 /* iretq를 사용해 스레드를 시작한다. */


### PR DESCRIPTION
## 작업 요약

- Priority Donation 구현 이후 발견된 scheduling edge case를 보완했습니다.
- `donate_priority()`에 donation chain depth limit을 추가하고, 잘못된 인자에 대해 `ASSERT`로 invariant를 명확히 했습니다.
- `lock_acquire()`에서 현재 thread와 lock holder의 priority를 비교한 뒤 donation 여부를 결정하던 조건을 제거했습니다.
- lock을 기다리기 시작한 thread는 priority 크기와 관계없이 holder의 `donations` 리스트에 등록되도록 수정했습니다.
- READY 상태의 lock holder가 donation을 받은 뒤 `ready_list` 정렬이 stale해지는 문제를 막기 위해 `next_thread_to_run()`에서 선택 직전 재정렬하도록 수정했습니다.
- `lock_release()`에서 donation 제거, priority 복구, holder 해제, waiter wake-up 사이에 timer preemption이 끼어들지 않도록 interrupt-off critical section으로 묶었습니다.
- `cond_signal()`에서 condition waiters를 깨우기 직전에 다시 정렬해, donation 등으로 바뀐 최신 priority를 반영하도록 수정했습니다.

## 목표 테스트

- [x] `make tests/threads/priority-donate-one.result`
- [x] `make tests/threads/priority-donate-multiple.result`
- [x] `make tests/threads/priority-donate-multiple2.result`
- [x] `make tests/threads/priority-donate-lower.result`
- [x] `make tests/threads/priority-donate-nest.result`
- [x] `make tests/threads/priority-donate-chain.result`
- [x] `make tests/threads/priority-donate-sema.result`
- [x] `make tests/threads/priority-sema.result`
- [x] `make tests/threads/priority-condvar.result`

## 구현 전 의사코드

- lock 획득에 실패해 대기하게 되는 thread는 priority 크기와 관계없이 lock holder의 `donations` 리스트에 등록한다.
- `refresh_priority()`가 base priority와 현재 donations 중 최댓값을 기준으로 effective priority를 계산한다.
- donation 전파는 직접 lock holder에게 donor를 기록하고, holder chain은 제한 깊이 안에서 effective priority를 전파한다.
- scheduler가 다음 thread를 고르기 직전에 `ready_list`를 최신 effective priority 기준으로 다시 정렬한다.
- lock release 중 donation 제거부터 waiter wake-up까지는 하나의 atomic 구간으로 처리한다.
- condition variable signal 시점에는 waiters의 priority가 바뀌었을 수 있으므로 pop 직전에 재정렬한다.

## 유지해야 할 invariant

- `thread->priority`는 donation이 반영된 effective priority다.
- `thread->base_priority`는 donation을 제외한 원래 priority다.
- `donations` 리스트에는 `thread.elem`이 아니라 `donation_elem`을 사용한다.
- 하나의 `list_elem`은 동시에 두 리스트에 들어가지 않는다.
- 어떤 thread가 lock을 기다리고 있다면, 그 lock holder의 `donations` 리스트에는 해당 thread가 등록되어 있어야 한다.
- lock release 시 `donor->wait_lock == lock`인 donation만 제거한다.
- READY thread의 priority가 donation으로 변경 가능하니, scheduler는 최신 priority 기준으로 thread를 선택해야 한다.

## 구현 내용

- `lock_acquire()`
  - 기존에는 현재 thread의 priority가 holder보다 높을 때만 `donate_priority()`를 호출했습니다.
  - 이제 lock holder가 존재하면 priority 크기와 관계없이 `donate_priority()`를 호출합니다.
  - 이 변경으로 “처음에는 priority가 낮아 donation 대상이 아니었지만, 나중에 nested donation으로 priority가 올라가는 waiter”도 holder의 `donations` 리스트에 남게 됩니다.

- `donate_priority()`
  - NULL 인자는 `ASSERT`로 검증하도록 변경했습니다.
  - donation chain 전파 깊이를 `DONATION_DEPTH_LIMIT`으로 제한했습니다.
  - 직접 receiver에는 donation 관계를 기록하고, 상위 holder chain에는 effective priority 값을 전파합니다.
  - 실제 priority 반영 여부는 `refresh_priority()`가 base priority와 donations의 최댓값을 기준으로 결정합니다.

- `next_thread_to_run()`
  - READY 상태의 lock holder가 donation을 받아 기존 삽입 순서와 실제 priority가 달라질 수 있으므로, `list_pop_front()` 전에 `ready_list`를 재정렬합니다.

- `lock_release()`
  - `remove_donation()`, `refresh_priority()`, `lock->holder = NULL`, `sema_up()`을 interrupt-off 구간으로 묶었습니다.
  - donation 제거 후 waiter가 깨기 전 timer preemption이 발생해 medium priority thread가 먼저 실행되는 window를 줄였습니다.

- `cond_signal()`
  - condition waiters를 pop하기 직전에 `semaphore_priority_compare` 기준으로 재정렬합니다.
  - waiters에 들어간 이후 donation으로 priority가 바뀐 경우를 반영합니다.

## 테스트 결과

- 회귀 테스트 ALL PASS

## 위험 요소

- `next_thread_to_run()`에서 매번 `list_sort()`를 호출하므로 ready list 크기에 따라 비용이 증가할 수 있습니다.
- `lock_release()`의 interrupt-off 구간이 기존보다 길어졌습니다.
- priority가 낮은 waiter도 holder의 `donations` 리스트에 등록되므로, `refresh_priority()`가 항상 base priority와 donations 최댓값을 기준으로 계산해야 합니다.
- 같은 thread의 `donation_elem`이 중복 삽입되지 않도록, 한 thread가 동시에 하나의 lock만 기다린다는 invariant에 의존합니다.

## 학습 메모

- lock holder는 lock을 가지고 있어도 running 상태가 아닐 수 있고, READY 상태로 `ready_list`에 있을 수 있습니다.
- donation으로 READY thread의 priority가 바뀌면 삽입 시점의 ready list 정렬만으로는 충분하지 않습니다.
- `sema_up()` 내부의 interrupt disable은 공용 semaphore 자료구조 보호를 위한 것이므로, caller가 interrupt를 끈 상태로 호출해도 제거하면 안 됩니다.
- condition waiters도 삽입 이후 priority가 바뀔 수 있으므로, 깨우는 시점의 최신 priority 기준 선택이 필요합니다.
- `donations` 리스트는 “나보다 높은 priority를 준 thread 목록”이 아니라, 더 정확히는 “내가 가진 lock을 기다리는 직접 waiter 목록”으로 유지하는 쪽이 nested donation에 안전합니다.

## 체크리스트

- [x] build 성공
- [x] 회귀 테스트 통과
