### PR TITLE
refactor(project3): prepare userprog and VM foundations

### DIFF
--- a/docs/ai/001_PR154_Project3_기반_수정_기록.md
+++ b/docs/ai/001_PR154_Project3_기반_수정_기록.md
@@ -1,0 +1,44 @@
+# PR154 Project3 기반 수정 기록
+
+## 전제
+
+이번 브랜치 `codex/pr154-project3-review-fixes`에서는 PR 리뷰 대응을 위해 이전 AGENTS 지침 중 "Pintos 과제 구현 코드를 직접 수정하지 않는다"와 "테스트를 직접 수행하지 않는다" 제한을 해제했다.
+
+목표는 Project 3로 이어가기 전에 Project 2 userprog의 process/file lifetime 문제가 숨은 테스트나 이후 VM 구현에 영향을 주지 않도록, 리뷰에서 지적된 문제만 최소 범위로 직접 수정하는 것이다.
+
+## 수정 내용
+
+### 1. child_status ref count release 원자화
+
+- 위치: `pintos/userprog/process.c`의 `child_status_release()`
+- 변경: `ref_cnt` 감소와 `ref_cnt == 0` 판단을 `intr_disable()`/`intr_set_level()` 구간으로 보호했다.
+- 이유: parent의 `wait`/exit 경로와 child의 exit 경로가 같은 `child_status`를 release할 수 있으므로, timer preemption으로 `ref_cnt` 감소가 lost update 되는 상황을 막아야 한다.
+- 유지한 invariant: `free()`는 최종 참조가 내려간 뒤에만 수행하고, `process_wait()`의 `list_remove()`는 release 전에 수행하는 기존 순서를 유지했다.
+
+### 2. fork child의 running executable deny-write lifetime 상속
+
+- 위치: `pintos/userprog/process.c`의 `__do_fork()`
+- 변경: fd table 복제 성공 후, parent의 `running_file`이 있으면 `file_duplicate()`로 child의 `running_file`을 별도로 복제한다.
+- 이유: `running_file`은 fd table과 별개 필드라서 fd 복제만으로는 실행 중인 파일의 deny-write lifetime이 child에게 이어지지 않는다. parent가 먼저 exit하더라도 fork child가 같은 executable image를 실행 중이면 deny-write가 유지되어야 한다.
+- 실패 처리: `file_duplicate()`가 실패하면 fork 전체를 실패 처리한다. 이미 복제된 fd와 `running_file`은 기존 `thread_exit()` -> `process_exit()` cleanup 경로로 정리된다.
+
+### 3. Project 2 load_segment file offset 공유 제거
+
+- 위치: `pintos/userprog/process.c`의 `#ifndef VM` 아래 `load_segment()`
+- 변경: `file_seek()` + `file_read()` 조합을 없애고, page별 `ofs`를 사용해 `file_read_at()`으로 읽는다. 파일 시스템 접근은 기존 전역 `filesys_lock`으로 감쌌다.
+- 이유: `struct file`의 `pos`는 mutable state라 concurrent load나 duplicate된 file object 경로에서 섞일 수 있다. offset 기반 읽기를 쓰면 segment load가 file position에 의존하지 않는다.
+- Project 3 관련: 이 함수는 `#ifndef VM` 경로라 VM 빌드의 lazy load 구현과는 별개지만, Project 2 기반 안정성과 PR 리뷰 해결을 위해 정리했다.
+
+## 검증 결과
+
+컨테이너 `bcb5da26d1e9` 안에서 `source /workspaces/pintos_22.04_lab_docker/pintos/activate` 후 검증했다.
+
+- `make -C pintos/userprog`: 통과
+- 직접 영향권 테스트 PASS: `fork-once`, `fork-multiple`, `fork-read`, `wait-simple`, `wait-twice`, `exec-read`, `rox-simple`, `rox-child`, `rox-multichild`
+- `tests/userprog/no-vm/multi-oom`: 아직 FAIL
+
+`multi-oom` 실패 로그는 반복 중 `Should return > 0.` 및 최종 반복 깊이 저하를 보고한다. 이번 리뷰의 `child_status` ref count lost update 가능성은 막았지만, 현재 `multi-oom` 실패는 abnormal child가 많은 자원을 연 뒤 죽는 경로에서 별도 자원 회수 또는 fork 실패 처리 문제가 남아 있을 가능성이 크다. 따라서 이 브랜치는 PR 리뷰 3개 항목의 직접 수정으로는 완료되지만, `multi-oom`까지 완전 통과를 목표로 하면 후속 디버깅이 필요하다.
+
+## 참고
+
+macOS host에서 직접 `make -C pintos/userprog`를 실행하면 ARM clang이 Pintos x86 옵션인 `-mno-sse`를 지원하지 않아 실패한다. 검증은 x86_64 Ubuntu devcontainer에서 수행해야 한다.

--- a/docs/ai/002_Project3_기반_리팩토링_계획.md
+++ b/docs/ai/002_Project3_기반_리팩토링_계획.md
@@ -1,0 +1,76 @@
+# Project 3 기반 리팩토링 기록
+
+## 이번 브랜치의 기준
+
+이번 브랜치 `codex/pr154-project3-review-fixes`에서는 Project 3로 이어가기 위해 리뷰 대응과 직접 리팩토링을 허용했다. 목표는 Project 3 기능을 미리 구현하는 것이 아니라, Project 2 동작을 유지하면서 이후 VM 구현을 얹기 쉬운 책임 경계를 만드는 것이다.
+
+`multi-oom` 후속 디버깅은 이번 범위의 통과 조건이 아니다. 현재 리팩토링은 fork/exec/wait/rox 계열의 기본 동작을 보존하고, `multi-oom`에서 드러날 수 있는 누수나 exit 경로 문제는 별도 작업으로 추적한다.
+
+## Project 2에서 Project 3로 넘어갈 때 위험한 지점
+
+- `process.c`의 executable loading은 file position을 공유하는 `file_seek()` + `file_read()`에 의존하면 fork/exec/load가 겹칠 때 깨지기 쉽다. 실행 파일 segment는 offset 기반으로 읽는 흐름을 기본값으로 둔다.
+- `running_file`은 fd table과 다른 ownership을 가진다. 실행 중인 파일의 deny-write lifetime은 exec 성공부터 process cleanup까지 이어져야 하며, fork child도 별도 file object로 이 상태를 이어받아야 한다.
+- user pointer 검증이 `pml4_get_page()` 호출마다 흩어져 있으면 lazy page fault를 도입할 때 syscall마다 정책이 달라질 수 있다. Project 3에서는 한 helper에서 SPT 조회와 fault-in 가능 여부를 판단하도록 바꾼다.
+- `child_status`처럼 parent와 child가 함께 만지는 record는 ref count와 free 판단을 원자적으로 유지해야 한다. 이 invariant가 깨지면 Project 3 구현 중 반복 fork/exit 테스트에서 디버깅 비용이 커진다.
+
+## 책임 분리 기준
+
+### `process.c`
+
+- process lifetime, fork/exec/wait, executable load, initial stack setup을 담당한다.
+- `running_file_close()`, `running_file_install()`, `running_file_duplicate()`에 실행 파일 deny-write ownership을 모은다.
+- ELF header, program header, segment body는 `read_file_exact_at()`을 통해 offset 기반으로 읽는다. file position은 syscall의 일반 fd read/write 흐름과 섞이지 않게 둔다.
+- argument stack layout은 공개 ABI이므로 Project 3에서도 같은 `argc`, `argv`, fake return address 배치를 유지한다.
+
+### `syscall.c`
+
+- syscall dispatch와 user/kernel copy boundary를 담당한다.
+- user buffer 검증은 `validate_user_buffer()` 한 곳에서 read/write 정책을 나눈다.
+- Project 3에서는 이 helper의 present-page 판정을 `spt_find_page()`와 `vm_try_handle_fault()` 경로로 연결한다. syscall마다 직접 SPT를 만지는 방식은 피한다.
+- `mmap`/`munmap` syscall entry는 Project 3 기능 작업에서 추가한다. 이번 리팩토링은 연결 지점만 만든다.
+
+### `vm/*`
+
+- `struct supplemental_page_table`은 process-owned virtual page map이다.
+- `struct page`는 SPT entry, type-specific state, frame 역참조를 가진다.
+- `struct frame`은 physical frame table의 entry가 될 준비를 한다. eviction list 정책은 Project 3 기능 작업에서 정한다.
+
+## SPT/hash/page/frame ownership 규칙
+
+- `struct supplemental_page_table.pages`는 `struct hash`로 둔다.
+- hash key는 page-aligned user virtual address인 `page->va`다.
+- 각 `struct page`는 정확히 하나의 SPT hash에 들어간다.
+- `page->spt_elem`은 SPT hash에 들어가 있는 동안 다른 list/hash에 재사용하지 않는다.
+- `page->frame`은 현재 page가 claim되어 물리 frame과 연결되어 있을 때만 유효하다.
+- `frame->page`는 frame을 점유한 page를 역참조한다.
+- `frame->frame_elem`은 이후 frame table 순회와 eviction 후보 선정에 쓸 hook이다. 이번 리팩토링에서는 필드와 주석만 고정한다.
+
+## Lazy loading과 mmap에서 이어받을 결정
+
+- executable lazy loading과 mmap은 모두 file position을 공유하지 않는 `file_read_at()` 기반으로 설계한다.
+- VM용 `load_segment()`는 page마다 `file`, `ofs`, `page_read_bytes`, `page_zero_bytes`를 담은 aux 구조체를 넘기는 방향으로 이어간다.
+- aux ownership은 page initializer가 가져가고, page가 실제로 claim되거나 destroy될 때 정리하는 쪽이 자연스럽다.
+- mmap은 executable loading과 같은 offset/read/zero 계산 규칙을 재사용하되, file-backed page의 dirty write-back 정책은 `vm/file.c`에서 닫는다.
+
+## 잔여 리스크
+
+- `multi-oom`은 여전히 별도 디버깅 대상이다. 이번 리팩토링은 ref count 원자성, running executable lifetime, file offset 기반 loading처럼 기반 결함을 줄이는 데 초점을 맞췄다.
+- VM 구현 전까지 `include/vm/vm.h`의 SPT/hash 구조는 선언 수준의 기반이다. 실제 hash 함수, less 함수, insert/find/remove 구현은 Project 3 기능 작업에서 채운다.
+- syscall pointer 검증 helper는 아직 Project 2의 present-page 정책을 따른다. Lazy loading 도입 시 이 helper를 먼저 갱신해야 한다.
+
+## 검증 기록
+
+검증은 macOS host가 아니라 x86_64 Ubuntu devcontainer에서 수행했다.
+
+- `make -C pintos/userprog`: PASS
+- `fork-once`: PASS
+- `fork-multiple`: PASS
+- `fork-read`: PASS
+- `wait-simple`: PASS
+- `wait-twice`: PASS
+- `exec-read`: PASS
+- `rox-simple`: PASS
+- `rox-child`: PASS
+- `rox-multichild`: PASS
+- `multi-oom`: FAIL, 이번 리팩토링의 통과 조건이 아니며 별도 디버깅 대상으로 남긴다.
+- `git diff --check`: PASS

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -1,6 +1,8 @@
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
+#include "lib/kernel/hash.h"
+#include "lib/kernel/list.h"
 #include "threads/palloc.h"
 
 enum vm_type {
@@ -46,7 +48,10 @@ struct page {
 	void *va;              /* user space 기준 주소 */
 	struct frame *frame;   /* frame을 가리키는 역참조 */
 
-	/* 여러분의 구현 */
+	/* SPT ownership:
+	 * 각 page는 정확히 한 supplemental_page_table의 pages hash에 들어간다.
+	 * key는 page-aligned user va이며, 이 elem은 hash 삭제 뒤에만 재사용된다. */
+	struct hash_elem spt_elem;
 
 	/* 타입별 데이터는 union에 묶여 있다.
 	 * 각 함수는 현재 union을 자동으로 감지한다. */
@@ -64,6 +69,9 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
+	/* 이후 eviction 정책에서 frame table 순회에 사용할 hook.
+	 * 이번 refactor에서는 필드만 고정하고 eviction 구현은 Project 3 단계로 남긴다. */
+	struct list_elem frame_elem;
 };
 
 /* page 연산을 위한 함수 테이블.
@@ -86,6 +94,10 @@ struct page_operations {
  * 이 struct의 설계를 특정 방식으로 강제하고 싶지는 않다.
  * 설계는 전부 여러분에게 달려 있다. */
 struct supplemental_page_table {
+	/* Process-owned virtual page map.
+	 * key: page->va rounded down to page boundary
+	 * value: struct page through page.spt_elem */
+	struct hash pages;
 };
 
 #include "threads/thread.h"

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -31,6 +31,9 @@ static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens[]);
 static void initd (void *f_name);
 static void __do_fork (void *);
+static void running_file_close (struct thread *t);
+static void running_file_install (struct thread *t, struct file *file);
+static bool running_file_duplicate (struct thread *dst, struct thread *src);
 
 struct fork_aux {
 	struct thread *parent;
@@ -94,15 +97,23 @@ child_status_find (struct thread *parent, tid_t child_tid) {
 /* child_status_release () */
 static void
 child_status_release (struct child_status *cs) {
+	bool should_free;
+	enum intr_level old_level;
+
 	/* record가 NULL이면 이미 메모리 해제된 것이므로 바로 return */
 	if (cs == NULL) {
 		return;
 	}
+
+	old_level = intr_disable ();
 	ASSERT(cs->ref_cnt > 0);
 	/* 이 record의 참조 수를 1 감소시킨다. */
 	cs->ref_cnt--;
 	/* ref_cnt가 0이면 malloc으로 할당 받았던 record의 memory를 free */
-	if (cs->ref_cnt == 0) {
+	should_free = cs->ref_cnt == 0;
+	intr_set_level (old_level);
+
+	if (should_free) {
 		free(cs);
 	}
 }
@@ -119,6 +130,48 @@ process_init (void)
 {
 	struct thread *current = thread_current();
 	fd_init (current);
+}
+
+/* running_file은 fd table과 별개의 실행 파일 lifetime record다.
+ * file_deny_write()는 file object가 닫힐 때 풀리므로, exec 성공부터
+ * process cleanup까지 file을 열어 둔다는 invariant를 이 helper들에 모은다. */
+static void
+running_file_close (struct thread *t)
+{
+	if (t->running_file == NULL)
+		return;
+
+	lock_acquire (&filesys_lock);
+	file_close (t->running_file);
+	lock_release (&filesys_lock);
+	t->running_file = NULL;
+}
+
+static void
+running_file_install (struct thread *t, struct file *file)
+{
+	ASSERT (t->running_file == NULL);
+	ASSERT (file != NULL);
+
+	lock_acquire (&filesys_lock);
+	file_deny_write (file);
+	lock_release (&filesys_lock);
+	t->running_file = file;
+}
+
+static bool
+running_file_duplicate (struct thread *dst, struct thread *src)
+{
+	ASSERT (dst->running_file == NULL);
+
+	if (src->running_file == NULL)
+		return true;
+
+	lock_acquire (&filesys_lock);
+	dst->running_file = file_duplicate (src->running_file);
+	lock_release (&filesys_lock);
+
+	return dst->running_file != NULL;
 }
 
 /* FILE_NAME command line으로 첫 user process를 시작할 kernel thread를 만든다.
@@ -381,6 +434,9 @@ __do_fork (void *aux)
 	if (!fd_duplicate_all (current, parent))
 		goto error;
 
+	if (!running_file_duplicate (current, parent))
+		goto error;
+
 	/* child 입장에서는 fork()의 반환값이 0이어야 한다. */
 	if_.R.rax = 0;
 
@@ -531,13 +587,7 @@ process_exit (void)
 	 * TODO: 프로세스 종료 메시지를 구현하세요(참고:
 	 * TODO: project2/process_termination.html).
 	 * TODO: 여기서 프로세스 자원 정리를 구현하는 것을 권장합니다. */
-	if (curr->running_file != NULL) {
-		lock_acquire (&filesys_lock);
-		file_allow_write (curr->running_file);
-		file_close (curr->running_file);
-		lock_release (&filesys_lock);
-		curr->running_file = NULL;
-	}
+	running_file_close (curr);
 
 	/* 유저 프로세스의 thread라면 종료 메시지 출력, pure kernel thread면 메시지 출력 X 
 	 * 유저 프로세스라면 pml4(페이지 테이블)가 존재한다.
@@ -570,10 +620,7 @@ static void
 process_cleanup (void)
 {
 	struct thread *curr = thread_current ();
-	if (curr->running_file != NULL) {
-		file_close (curr->running_file); // 내부에서 file_allow_write() 호출
-		curr->running_file = NULL;
-	}
+	running_file_close (curr);
 
 #ifdef VM
 	supplemental_page_table_kill (&curr->spt);
@@ -670,6 +717,30 @@ static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
 						 uint32_t read_bytes, uint32_t zero_bytes,
 						 bool writable);
 
+static bool
+read_file_exact_at (struct file *file, void *buffer, off_t size, off_t ofs)
+{
+	off_t bytes_read;
+
+	lock_acquire (&filesys_lock);
+	bytes_read = file_read_at (file, buffer, size, ofs);
+	lock_release (&filesys_lock);
+
+	return bytes_read == size;
+}
+
+static off_t
+file_length_synchronized (struct file *file)
+{
+	off_t length;
+
+	lock_acquire (&filesys_lock);
+	length = file_length (file);
+	lock_release (&filesys_lock);
+
+	return length;
+}
+
 /* FILE_NAME에서 ELF 실행 파일을 현재 스레드에 로드합니다.
  * 실행 파일의 진입점을 *RIP에 저장하고 초기 스택 포인터를 *RSP에 저장합니다.
  * 성공하면 true, 그렇지 않으면 false를 반환합니다. */
@@ -716,15 +787,13 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
  	 * "어떤 아키텍처용인지",
  	 * "program header가 어디에 몇 개 있는지" 같은 정보가 들어 있습니다.
 	*/
-	lock_acquire (&filesys_lock);
-	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr
+	if (!read_file_exact_at (file, &ehdr, sizeof ehdr, 0)
 			|| memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7)
 			|| ehdr.e_type != 2
 			|| ehdr.e_machine != 0x3E
 			|| ehdr.e_version != 1
 			|| ehdr.e_phentsize != sizeof (struct Phdr)
 			|| ehdr.e_phnum > 1024) {
-		lock_release (&filesys_lock);
 		printf ("load: %s: error loading executable\n", argv_tokens[0]);
 		goto done;
 	}
@@ -739,7 +808,6 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
  	 * 모든 header가 실제로 메모리에 올라가는 것은 아니고,
  	 * PT_LOAD 타입인 header만 실제 코드/데이터 세그먼트로 메모리에 적재됩니다.
  	 */
-	lock_release (&filesys_lock);
 	file_ofs = ehdr.e_phoff;
 
 	/* 각 프로그램 헤더를 순회하며 메모리에 적재할 세그먼트를 찾는다. */
@@ -747,19 +815,13 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 		struct Phdr phdr;
 
 		/* program header를 읽을 위치가 파일 범위를 벗어나면 잘못된 ELF입니다. */
-		if (file_ofs < 0 || file_ofs > file_length (file))
+		if (file_ofs < 0 || file_ofs > file_length_synchronized (file))
 			goto done;
 
-		/* 현재 program header 위치로 이동합니다. */
-		lock_acquire (&filesys_lock);
-		file_seek (file, file_ofs);
-
-		/* 프로그램 헤더 1개 읽기 */
-		if (file_read (file, &phdr, sizeof phdr) != sizeof phdr) {
-			lock_release (&filesys_lock);
+		/* program header도 file position을 움직이지 않고 offset 기준으로 읽는다. */
+		if (!read_file_exact_at (file, &phdr, sizeof phdr, file_ofs))
 			goto done;
-		}
-		lock_release (&filesys_lock);
+
 		/* 다음 헤더 위치로 이동 */
 		file_ofs += sizeof phdr;
 
@@ -866,8 +928,9 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 	*/
 	if_->rip = ehdr.e_entry;
 
-	/* TODO: 여기에 코드를 작성하세요.
-	 * TODO: 인자 전달을 구현하세요(참고: project2/argument_passing.html). */
+	/* Argument passing은 load()가 만든 첫 stack page 안에서 끝낸다.
+	 * Project 3에서도 setup_stack()이 즉시 claim한 첫 stack page 위에
+	 * 같은 layout을 유지하면 syscall ABI를 바꾸지 않고 이어갈 수 있다. */
 	uintptr_t rsp = if_->rsp;
 
 	/* 스택에 인자 문자열 자체를 먼저 복사해 역순으로 push */
@@ -884,12 +947,12 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 	/* rsp는 원래 uintptr_t 타입이므로, rsp를 8로 나눈 나머지를 원래 rsp에서 빼주면 8의 배수로 내림 정렬이 된다.*/
 	rsp -= (rsp % 8);
 	if (rsp < USER_STACK - PGSIZE) {
-			goto done;
+		goto done;
 	}
 	/* NULL pointer 크기 만큼 rsp 내려감 */
 	rsp -= 8;
 	if (rsp < USER_STACK - PGSIZE) {
-			goto done;
+		goto done;
 	}
 	/* argv[argc] = NULL 
 	 * uintptr_t는 주소를 담을 수 있는 정수 타입이다.
@@ -915,7 +978,7 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 
 	rsp -= 8;
 	if (rsp < USER_STACK - PGSIZE) {
-			goto done;
+		goto done;
 	}
 	/* fake return address */
 	*(uintptr_t *) rsp = 0;
@@ -925,16 +988,8 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 	if_->R.rsi = (uint64_t) argv_addr;
 
 	success = true;
-	file_deny_write (file);
-	t->running_file = file;
-
-	if (success) {
-		lock_acquire (&filesys_lock);
-		file_deny_write (file);
-		lock_release (&filesys_lock);
-		t->running_file = file;
-		file = NULL;
-	}
+	running_file_install (t, file);
+	file = NULL;
 	
 done:
 	/* 로드가 성공하든 실패하든 여기로 옵니다. */
@@ -962,7 +1017,7 @@ validate_segment (const struct Phdr *phdr, struct file *file)
 		return false;
 
 	/* p_offset은 FILE 내부를 가리켜야 합니다. */
-	if (phdr->p_offset > (uint64_t)file_length (file))
+	if (phdr->p_offset > (uint64_t) file_length_synchronized (file))
 		return false;
 
 	/* p_memsz는 p_filesz보다 적어도 커야 합니다. */
@@ -1024,7 +1079,6 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	ASSERT (pg_ofs(upage) == 0);
 	ASSERT (ofs % PGSIZE == 0);
 
-	file_seek (file, ofs);
 	while (read_bytes > 0 || zero_bytes > 0)
 	{
 		/* 이 페이지를 어떻게 채울지 계산하세요.
@@ -1039,7 +1093,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 			return false;
 
 		/* 이 페이지를 로드합니다. 실행 파일 내용을 일단 커널이 접근 가능한 메모리에 읽어옴  */
-		if (file_read (file, kpage, page_read_bytes) != (int) page_read_bytes) {
+		if (!read_file_exact_at (file, kpage, page_read_bytes, ofs)) {
 			palloc_free_page (kpage);
 			return false;
 		}
@@ -1058,6 +1112,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
+		ofs += page_read_bytes;
 	}
 	return true;
 }
@@ -1101,6 +1156,13 @@ install_page (void *upage, void *kpage, bool writable)
 /* 여기부터의 코드는 project 3 이후에 사용됩니다.
  * 함수를 project 2에만 구현하고 싶다면 위쪽 블록에 구현하세요. */
 
+struct lazy_load_segment_aux {
+	struct file *file;             /* page fault 때 읽을 executable 또는 mmap file */
+	off_t ofs;                     /* file_read_at()에 넘길 page별 시작 offset */
+	size_t page_read_bytes;        /* 파일에서 채울 byte 수 */
+	size_t page_zero_bytes;        /* 나머지 zero-fill byte 수 */
+};
+
 static bool
 lazy_load_segment (struct page *page, void *aux)
 {
@@ -1137,7 +1199,9 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* TODO: lazy_load_segment에 정보를 전달할 수 있도록 aux를 설정하세요. */
+		/* Project 3 구현 시 struct lazy_load_segment_aux를 page마다 만들어
+		 * file, offset, read/zero byte 수를 넘긴다. 이렇게 하면 lazy load와
+		 * mmap 모두 file position 공유 없이 file_read_at() 기반으로 이어갈 수 있다. */
 		void *aux = NULL;
 		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
 											writable, lazy_load_segment, aux))
@@ -1147,6 +1211,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
+		ofs += page_read_bytes;
 	}
 	return true;
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -34,6 +34,11 @@ static void sys_seek (int fd, unsigned position);
 static unsigned sys_tell (int fd);
 static void sys_close (int fd);
 
+enum user_access {
+	USER_ACCESS_READ,
+	USER_ACCESS_WRITE,
+};
+
 /* 시스템 콜.
  *
  * 이전에는 system call 서비스가 interrupt handler(예: linux의 int 0x80)에 의해 처리되었다. 그러나
@@ -169,68 +174,57 @@ syscall_handler (struct intr_frame *f)
 	}
 }
 
-void
-validate_user_read (const void *buffer, size_t size)
+/* Project 2는 pml4에 이미 매핑된 page만 user buffer로 인정한다.
+ * Project 3에서 lazy page가 들어오면 이 helper의 "page present" 판정을
+ * spt_find_page()/vm_try_handle_fault 흐름과 연결하면 된다. */
+static void
+validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 {
-    if (size == 0) return;
-    if (buffer == NULL) thread_exit (); // size > 0인데 주소가 없다, 메모리 접근 불가.
+	if (size == 0)
+		return;
+	if (buffer == NULL)
+		thread_exit ();
 
 	// 반복문 돌리기 위해서 주소를 1바이트씩 이동시킬 수 있게 변경: buffer의 시작 바이트 주소
-    const uint8_t *bf =(const uint8_t *) buffer;
+	const uint8_t *bf = (const uint8_t *) buffer;
 	// end address 따로 정의: buffer의 끝 바이트 주소
-	const uint8_t *end_adr = bf+size-1;
+	const uint8_t *end_adr = bf + size - 1;
 
 	// 끝 주소 = 시작 주소보다 같거나 커야 한다, 근데 시작 주소보다 작다 (초과분이 잘린거임)
-	if (end_adr < bf) thread_exit (); // 사이즈가 말도 안되게 큰 경우, 주소 오버플로우 처리
+	if (end_adr < bf)
+		thread_exit ();
 
 	// 순회할 시작페이지, 끝 페이지 정의
 	const uint8_t *start_page = pg_round_down (bf);
 	const uint8_t *end_page = pg_round_down (end_adr);
 
-    // buffer가 걸쳐진 모든 page를 순회 (페이지 단위로 확인)
-    // buffer의 시작주소 + PGSIZE: buffer의 끝 주소까지 순회
-    for (const uint8_t *i = start_page; i <= end_page; i+=PGSIZE) {
+	// buffer가 걸쳐진 모든 page를 순회 (페이지 단위로 확인)
+	// buffer의 시작주소 + PGSIZE: buffer의 끝 주소까지 순회
+	for (const uint8_t *i = start_page; i <= end_page; i += PGSIZE) {
 		// page 시작주소가 user virtual address 범위 안에 있지 않다면 현재 프로세스 exit(-1)
-		if (!is_user_vaddr (i)) thread_exit ();
-		// page가 실제 mapped 되어있지 않다면 현재 프로세스 exit(-1)
-		// pml4_get_page 함수 인수 확인, thread_current()->pml4: 현재 실행중인 함수 인수 테이블
-		if (!pml4_get_page (thread_current()->pml4, i)) thread_exit ();
+		if (!is_user_vaddr (i))
+			thread_exit ();
+
+		uint64_t *pte = pml4e_walk (thread_current ()->pml4,
+				(const uint64_t) i, false);
+		if (pte == NULL || (*pte & PTE_P) == 0 || (*pte & PTE_U) == 0)
+			thread_exit ();
+
+		if (access == USER_ACCESS_WRITE && (*pte & PTE_W) == 0)
+			thread_exit ();
 	}
 }
 
 void
-validate_user_write(const void *buffer, size_t size)
+validate_user_read (const void *buffer, size_t size)
 {
-	if (size == 0) return;
-    if (buffer == NULL) thread_exit (); // size > 0인데 주소가 없다, 메모리 접근 불가. 바로 false
+	validate_user_buffer (buffer, size, USER_ACCESS_READ);
+}
 
-	// 반복문 돌리기 위해서 주소를 1바이트씩 이동시킬 수 있게 변경: buffer의 시작 바이트 주소
-    const uint8_t *bf = (const uint8_t *) buffer;
-	// end address 따로 정의: buffer의 끝 바이트 주소
-	const uint8_t *end_adr = bf+size-1;
-
-	// 끝 주소 = 시작 주소보다 같거나 커야 한다, 근데 시작 주소보다 작다 (초과분이 잘린거임)
-	if (end_adr < bf) thread_exit (); // 사이즈가 말도 안되게 큰 경우, 주소 오버플로우 처리
-
-	// 순회할 시작페이지, 끝 페이지 정의
-	const uint8_t *start_page = pg_round_down (bf);
-	const uint8_t *end_page = pg_round_down (end_adr);
-
-    // buffer가 걸쳐진 모든 page를 순회 (페이지 단위로 확인)
-    // buffer의 시작주소 + PGSIZE: buffer의 끝 주소까지 순회
-    for (const uint8_t *i = start_page; i <= end_page; i+=PGSIZE) {
-		// page 시작주소가 user virtual address 범위 안에 있지 않다면 현재 프로세스 exit(-1)
-		if (!is_user_vaddr (i)) thread_exit ();
-		// writable 페이지인지 검증 - PTE 사용
-		// pte가 NULL이 아닌지, *pte에 PTE_P가 있는지, *pte에 PTE_U가 있는지,  *pte에 PTE_W가 있는지 - 모두 충족해야함
-		uint64_t *pte = pml4e_walk (thread_current ()->pml4, (const uint64_t)i, false);
-
-		if (pte == NULL || (*pte & PTE_P) == 0 || (*pte & PTE_U) == 0)
-			thread_exit ();
-
-		if ((*pte & PTE_W) == 0)
-			thread_exit ();
-    }
+void
+validate_user_write (const void *buffer, size_t size)
+{
+	validate_user_buffer (buffer, size, USER_ACCESS_WRITE);
 }
 
 void


### PR DESCRIPTION
## 작업 요약

- PR #154 리뷰에서 지적된 Project 2 기반 결함을 수정했습니다.
- Project 3 진입을 위해 `process.c`, `syscall.c`, `vm.h`의 책임 경계를 정리했습니다.
- 수정 의도와 남은 리스크를 `docs/ai` 문서로 남겼습니다.

## 구현 전 의사코드

- `child_status_release`
  - interrupt disable
  - `ref_cnt--`
  - `ref_cnt == 0` 여부 저장
  - interrupt restore
  - 필요하면 free

- `fork`
  - page table 복제
  - fd table 복제
  - parent `running_file`이 있으면 child도 duplicate
  - fork child의 deny-write lifetime 유지

- `load`
  - ELF/header/segment read는 file position을 움직이지 않는 `file_read_at()` 기반 helper 사용
  - exec 성공 시 한 곳에서 `file_deny_write()` 적용
  - 실패 경로에서는 열린 file 정리

- `syscall`
  - read/write user buffer 검증을 공통 helper로 모음
  - Project 3에서 SPT/lazy fault-in으로 교체할 지점을 고정

## 유지해야 할 invariant

- `child_status.ref_cnt` 감소와 free 판단은 하나의 atomic 구간으로 유지한다.
- `running_file`은 fd table과 별개이며, exec 성공부터 process cleanup까지 열린 상태로 유지한다.
- fork child는 parent의 실행 파일 deny-write 상태를 별도 file object로 이어받는다.
- executable load는 공유 file position에 의존하지 않는다.
- syscall user pointer 검증 정책은 한 helper를 통해 적용한다.
- SPT에서 `page->spt_elem`은 한 SPT hash에만 속한다.

## 구현 내용

- `pintos/userprog/process.c`
  - `child_status_release()`의 ref count 감소를 interrupt-off 구간으로 보호했습니다.
  - `running_file_close/install/duplicate()` helper를 추가했습니다.
  - fork child가 parent의 `running_file`을 duplicate하도록 했습니다.
  - ELF header, program header, segment read를 `file_read_at()` 기반으로 정리했습니다.
  - 중복 `file_deny_write()` 호출을 제거하고 exec 성공 경로를 단일화했습니다.
  - VM용 lazy load aux 구조체 방향을 주석과 구조로 남겼습니다.

- `pintos/userprog/syscall.c`
  - `validate_user_read()`와 `validate_user_write()`의 중복을 `validate_user_buffer()`로 통합했습니다.
  - Project 3에서 `spt_find_page()` / `vm_try_handle_fault()`로 연결할 경계를 만들었습니다.

- `pintos/include/vm/vm.h`
  - `struct supplemental_page_table`을 `struct hash pages` 기반으로 잡았습니다.
  - `struct page`에 `spt_elem`을 추가했습니다.
  - `struct frame`에 이후 eviction 순회를 위한 `frame_elem`을 추가했습니다.

- `docs/ai`
  - PR #154 리뷰 수정 기록과 Project 3 기반 리팩토링 기록을 추가했습니다.


## 리뷰 질문

- `running_file` deny-write lifetime을 helper로 모은 방향이 Project 3 이후에도 유지하기 좋은지 확인 부탁드립니다.
- syscall user pointer 검증을 Project 3 lazy fault-in과 연결할 때 현재 helper 경계가 적절한지 확인 부탁드립니다.
- SPT/hash/page/frame ownership 규칙을 현재 구조로 고정해도 괜찮은지 확인 부탁드립니다.

## 위험 요소

- `multi-oom`은 아직 실패하며, 이번 PR의 통과 조건이 아니라 별도 디버깅 대상으로 남겼습니다.
- `vm.h`의 SPT/hash 구조는 기반만 잡은 상태이며, 실제 hash 함수와 insert/find/remove 구현은 Project 3 작업에서 이어가야 합니다.
- syscall pointer 검증은 아직 Project 2 기준의 present-page 정책입니다.

## 학습 메모

- 실행 중인 executable 보호는 fd table과 별개 lifetime으로 다뤄야 합니다.
- file object의 mutable position에 의존하면 concurrent exec/fork/load 상황에서 위험해질 수 있습니다.
- Project 3 lazy loading을 위해서는 syscall pointer validation, executable loading, SPT ownership의 경계를 미리 분리해두는 편이 안전합니다.

## 체크리스트

- [x] build 성공
- [x] 목표 테스트 통과
- [x] 관련 회귀 테스트 확인
- [x] debug print 제거
- [x] busy waiting 없음
- [x] interrupt off 구간 최소화
- [x] 테스트 이름 기반 하드코딩 없음
- [x] 복잡한 invariant는 주석 또는 문서에 설명