### PR TITLE
feat(project3): hash 기반 supplemental page table 구현

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -48,6 +48,8 @@ struct page {
 	void *va;              /* user space 기준 주소 */
 	struct frame *frame;   /* frame을 가리키는 역참조 */
 
+	struct hash_elem hash_elem;
+
 	/* 타입별 데이터는 union에 묶여 있다.
 	 * 각 함수는 현재 union을 자동으로 감지한다. */
 	union {
@@ -86,6 +88,7 @@ struct page_operations {
  * 이 struct의 설계를 특정 방식으로 강제하고 싶지는 않다.
  * 설계는 전부 여러분에게 달려 있다. */
 struct supplemental_page_table {
+	struct hash table;
 };
 
 #include "threads/thread.h"

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -34,7 +34,7 @@ less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
 	struct page* pa = hash_entry (a, struct page, hash_elem);
 	struct page* pb = hash_entry (b, struct page, hash_elem);
 
-	return pg_round_down(pa->va < pb->va);
+	return pg_round_down(pa->va) < pg_round_down(pb->va);
 }
 
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -7,6 +7,7 @@
 #include "hash.h"
 #include "../debug.h"
 #include "threads/malloc.h"
+#include "/workspaces/pintos/pintos/include/vm/vm.h"
 
 #define list_elem_to_hash_elem(LIST_ELEM)                       \
 	list_entry(LIST_ELEM, struct hash_elem, list_elem)
@@ -17,6 +18,13 @@ static struct hash_elem *find_elem (struct hash *, struct list *,
 static void insert_elem (struct hash *, struct list *, struct hash_elem *);
 static void remove_elem (struct hash *, struct hash_elem *);
 static void rehash (struct hash *);
+
+uint64_t
+hash_func (const struct hash_elem *e, void* aux) {
+	struct page* page = hash_entry (e, struct page, hash_elem);
+
+	return hash_bytes (page->va, sizeof page->va);
+}
 
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를
    초기화합니다. */

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -26,6 +26,14 @@ hash_func (const struct hash_elem *e, void* aux) {
 	return hash_bytes (page->va, sizeof page->va);
 }
 
+bool
+less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
+	struct page* pa = hash_entry (a, struct page, hash_elem);
+	struct page* pb = hash_entry (a, struct page, hash_elem);
+
+	return pa->va < pb->va;
+}
+
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를
    초기화합니다. */
 bool

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -19,17 +19,19 @@ static void insert_elem (struct hash *, struct list *, struct hash_elem *);
 static void remove_elem (struct hash *, struct hash_elem *);
 static void rehash (struct hash *);
 
+/* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
 uint64_t
 hash_func (const struct hash_elem *e, void* aux) {
 	struct page* page = hash_entry (e, struct page, hash_elem);
 
-	return hash_bytes (page->va, sizeof page->va);
+	return hash_bytes (&page->va, sizeof page->va);
 }
 
+/* 두 page의 key인 va 값을 비교한다. */
 bool
 less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
 	struct page* pa = hash_entry (a, struct page, hash_elem);
-	struct page* pb = hash_entry (a, struct page, hash_elem);
+	struct page* pb = hash_entry (b, struct page, hash_elem);
 
 	return pa->va < pb->va;
 }

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -7,7 +7,8 @@
 #include "hash.h"
 #include "../debug.h"
 #include "threads/malloc.h"
-#include "/workspaces/pintos/pintos/include/vm/vm.h"
+#include "vm/vm.h"
+#include "threads/vaddr.h"
 
 #define list_elem_to_hash_elem(LIST_ELEM)                       \
 	list_entry(LIST_ELEM, struct hash_elem, list_elem)
@@ -24,7 +25,7 @@ uint64_t
 hash_func (const struct hash_elem *e, void* aux) {
 	struct page* page = hash_entry (e, struct page, hash_elem);
 
-	return hash_bytes (&page->va, sizeof page->va);
+	return hash_bytes (pg_round_down(page->va), sizeof page->va);
 }
 
 /* 두 page의 key인 va 값을 비교한다. */
@@ -33,7 +34,7 @@ less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
 	struct page* pa = hash_entry (a, struct page, hash_elem);
 	struct page* pb = hash_entry (b, struct page, hash_elem);
 
-	return pa->va < pb->va;
+	return pg_round_down(pa->va < pb->va);
 }
 
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -7,8 +7,6 @@
 #include "hash.h"
 #include "../debug.h"
 #include "threads/malloc.h"
-#include "vm/vm.h"
-#include "threads/vaddr.h"
 
 #define list_elem_to_hash_elem(LIST_ELEM)                       \
 	list_entry(LIST_ELEM, struct hash_elem, list_elem)
@@ -20,22 +18,7 @@ static void insert_elem (struct hash *, struct list *, struct hash_elem *);
 static void remove_elem (struct hash *, struct hash_elem *);
 static void rehash (struct hash *);
 
-/* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
-uint64_t
-hash_func (const struct hash_elem *e, void* aux) {
-	struct page* page = hash_entry (e, struct page, hash_elem);
 
-	return hash_bytes (pg_round_down(page->va), sizeof page->va);
-}
-
-/* 두 page의 key인 va 값을 비교한다. */
-bool
-less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
-	struct page* pa = hash_entry (a, struct page, hash_elem);
-	struct page* pb = hash_entry (b, struct page, hash_elem);
-
-	return pg_round_down(pa->va) < pg_round_down(pb->va);
-}
 
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를
    초기화합니다. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -8,8 +8,9 @@
 static uint64_t
 hash_func (const struct hash_elem *e, void* aux) {
 	struct page* page = hash_entry (e, struct page, hash_elem);
+	void *va = pg_round_down(page->va);
 
-	return hash_bytes (pg_round_down(page->va), sizeof page->va);
+	return hash_bytes (&va, sizeof va);
 }
 
 /* 두 page의 key인 va 값을 비교한다. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -84,7 +84,8 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	return page;
 }
 
-/* 검증 후 PAGE를 spt에 삽입한다. */
+/* PAGE를 spt에 삽입한다. 같은 va가 이미 있으면 false를 반환한다. */
+
 bool
 spt_insert_page (struct supplemental_page_table *spt,
 		struct page *page) {

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -97,9 +97,11 @@ struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	struct page *page = malloc (sizeof (struct page));
 	page->va = va;
-	/* TODO: 이 함수를 채워라. */
+
 	struct hash_elem *he = hash_find (&spt->table, &page->hash_elem);
 	free (page);
+	
+	if (he == NULL) return NULL;
 	page = hash_entry (he, struct page, hash_elem);
 
 	return page;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -85,8 +85,10 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		uninit_new (page, upage, init, type, aux, initializer);
 		
 		if (!spt_insert_page (spt, page)) {
+			free(page);
 			goto err;
 		}
+		return true;
 	}
 err:
 	return false;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -66,7 +66,10 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		}
 		struct page *page = malloc (sizeof (struct page));
 		uninit_new (page, upage, init, type, aux, initializer);
-		/* TODO: 페이지를 spt에 삽입한다. */
+		
+		if (!spt_insert_page (spt, page)) {
+			goto err;
+		}
 	}
 err:
 	return false;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -3,6 +3,7 @@
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+#include "lib/kernel/hash.c"
 
 /* 각 subsystem의 초기화 코드를 호출하여 virtual memory subsystem을 초기화한다. */
 void
@@ -183,7 +184,9 @@ vm_do_claim_page (struct page *page) {
 
 /* 새 supplemental page table을 초기화한다. */
 void
-supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
+supplemental_page_table_init (struct supplemental_page_table *spt) {
+	struct hash *hash = &spt->table;
+	hash_init (hash, hash_func, less_func, NULL);
 }
 
 /* supplemental page table을 src에서 dst로 복사한다. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -83,10 +83,13 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 
 /* 검증 후 PAGE를 spt에 삽입한다. */
 bool
-spt_insert_page (struct supplemental_page_table *spt UNUSED,
-		struct page *page UNUSED) {
+spt_insert_page (struct supplemental_page_table *spt,
+		struct page *page) {
 	int succ = false;
-	/* TODO: 이 함수를 채워라. */
+	
+	if (hash_insert (spt, &page->hash_elem) == NULL) {
+		succ = true;
+	}
 
 	return succ;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -78,8 +78,12 @@ err:
 /* spt에서 VA를 찾아 page를 반환한다. 오류 시 NULL을 반환한다. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-	struct page *page = NULL;
+	struct page *page = malloc (sizeof (struct page));
+	page->va = va;
 	/* TODO: 이 함수를 채워라. */
+	struct hash_elem *he = hash_find (&spt->table, &page->hash_elem);
+	free (page);
+	page = hash_entry (he, struct page, hash_elem);
 
 	return page;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -114,7 +114,8 @@ spt_insert_page (struct supplemental_page_table *spt,
 		struct page *page) {
 	int succ = false;
 	
-	if (hash_insert (spt, &page->hash_elem) == NULL) {
+	/* spt 자체가 아니라 내부 page table을 넘겨야 한다 */
+	if (hash_insert (&spt->table, &page->hash_elem) == NULL) {
 		succ = true;
 	}
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -3,7 +3,24 @@
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
-#include "lib/kernel/hash.c"
+
+/* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
+static uint64_t
+hash_func (const struct hash_elem *e, void* aux) {
+	struct page* page = hash_entry (e, struct page, hash_elem);
+
+	return hash_bytes (pg_round_down(page->va), sizeof page->va);
+}
+
+/* 두 page의 key인 va 값을 비교한다. */
+static bool
+less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
+	struct page* pa = hash_entry (a, struct page, hash_elem);
+	struct page* pb = hash_entry (b, struct page, hash_elem);
+
+	return pg_round_down(pa->va) < pg_round_down(pb->va);
+}
+
 
 /* 각 subsystem의 초기화 코드를 호출하여 virtual memory subsystem을 초기화한다. */
 void


### PR DESCRIPTION
## 작업 요약

- supplemental page table을 hash table 기반으로 구성
- `struct page`에 hash entry를 추가하고, page-aligned user virtual address를 SPT key로 사용
- SPT 초기화, 삽입, 조회 흐름을 구현
- `vm_alloc_page_with_initializer`에서 page 생성 후 SPT 삽입 성공 여부를 반환하도록 연결

## 목표 테스트

- [ ] `make tests/vm/<test-name>.result`

## 구현 전 의사코드

- supplemental page table 초기화 시 hash table을 초기화한다.
- page 할당 요청이 들어오면 같은 user virtual address가 이미 SPT에 있는지 확인한다.
- 중복 page가 없으면 page 객체를 만들고 VM type에 맞는 initializer를 설정한다.
- 생성한 page를 SPT hash table에 삽입한다.
- SPT 조회는 page-aligned virtual address를 기준으로 수행한다.

## 유지해야 할 invariant

- 한 SPT 안에서 같은 page-aligned user virtual address를 가진 page는 중복 삽입되지 않는다.
- SPT hash key는 page 내용이 아니라 `page->va`에 저장된 virtual address 값 기준이어야 한다.
- SPT 조회용 임시 객체는 조회 후 해제되어야 한다.
- SPT의 hash/less 기준은 `struct page`의 `va` 의미에 맞춰 유지되어야 한다.

## 구현 내용

- `struct supplemental_page_table`에 hash table을 추가
- `struct page`에 `hash_elem`을 추가해 SPT hash table entry로 사용할 수 있게 변경
- `supplemental_page_table_init`에서 SPT hash table 초기화
- `spt_insert_page`에서 중복 VA 여부를 hash table 기준으로 판단
- `spt_find_page`에서 page-aligned VA 기준으로 page 조회
- `vm_alloc_page_with_initializer`에서 VM type별 initializer를 선택하고, 생성한 page를 SPT에 삽입
- SPT hash/less helper를 VM page 구조에 맞게 `vm.c`에 배치

## 테스트 결과

```bash
cd pintos/threads/build
make tests/vm/<test-name>.result
