### PR TITLE
Issue 306 lazy load segment

### DIFF
--- a/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
+++ b/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
@@ -1,0 +1,183 @@
+# Project 3 빌드로 Project 2 테스트 실행 가이드
+
+## 목적
+
+Project 3 VM 구현이 들어간 커널, 즉 `pintos/vm` 빌드 결과로 Project 2 테스트 묶음을 돌리는 방법을 정리한다.
+
+핵심은 `pintos/userprog`에서 실행하지 않고 `pintos/vm`에서 실행하되, 테스트 목록만 Project 2 기준으로 덮어쓰는 것이다.
+
+## 기준 파일
+
+- `pintos/vm/Make.vars`
+  - Project 3 빌드는 `KERNEL_SUBDIRS`에 `vm`을 포함한다.
+  - 기본 `TEST_SUBDIRS`에는 `tests/vm`이 들어 있어 그냥 `make check`를 하면 Project 3 테스트까지 같이 돈다.
+- `pintos/userprog/Make.vars`
+  - Project 2 기본 테스트 목록은 `tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads`이다.
+- `pintos/Makefile.kernel`
+  - 상위 디렉터리에서 `make check`를 실행하면 `build/` 디렉터리를 준비한 뒤 `build` 안에서 실제 테스트를 실행한다.
+- `pintos/tests/Make.tests`
+  - `TEST_SUBDIRS`에 들어간 테스트 디렉터리의 `Make.tests`만 포함해서 테스트 목록을 만든다.
+
+## 전체 Project 2 테스트 실행
+
+저장소 바깥 루트가 `/Users/sisu/Projects/jungle/pintos`일 때:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make check TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads"
+```
+
+이 명령은 다음 성질을 가진다.
+
+- 빌드 위치는 `pintos/vm`이므로 `vm/Make.vars`의 Project 3 커널 구성을 사용한다.
+- `KERNEL_SUBDIRS`에는 `vm`이 포함된 상태로 유지된다.
+- `TEST_SUBDIRS`만 Project 2의 기본 테스트 목록으로 바뀐다.
+- 결과는 `pintos/vm/build/results`에 요약된다.
+- 각 테스트별 출력은 `pintos/vm/build/tests/.../*.output`, `*.errors`, `*.result`에 생긴다.
+
+## 단일 테스트만 실행
+
+예를 들어 `args-none` 하나만 Project 3 빌드로 확인하려면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make build/tests/userprog/args-none.result \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads"
+```
+
+`no-vm`의 `multi-oom`만 확인하려면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make build/tests/userprog/no-vm/multi-oom.result \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads"
+```
+
+상위 `pintos/vm`에서 `build/...` 형태로 호출하는 이유는 `Makefile.kernel`이 필요한 `build/tests/...` 디렉터리를 먼저 만들어 주기 때문이다. `pintos/vm/build`에 직접 들어가서 실행하면, 처음 실행하는 테스트 하위 디렉터리가 없어서 실패할 수 있다.
+
+## fork 제외 Project 2 테스트만 실행
+
+이 저장소에는 Project 3 빌드에서 Project 2 기본 테스트 묶음을 돌리되, `fork()` syscall에 직접 의존하는 테스트를 제외하는 편의 타깃을 추가했다.
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make p2-nofork-check
+```
+
+결과 파일만 갱신하고 요약 파일을 만들고 싶으면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make p2-nofork-results
+```
+
+요약은 `pintos/vm/build/selected-results`에 생긴다.
+
+파일 시스템 base 테스트까지 섞지 않고 userprog 중심으로만 보고 싶으면 다음 타깃을 쓴다.
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make p2-user-nofork-check
+```
+
+이 타깃은 `tests/userprog`와 `tests/threads`만 포함하고, `tests/filesys/base`와 `tests/userprog/no-vm`은 제외한다.
+
+제외되는 테스트는 다음 항목이다.
+
+```text
+tests/userprog/fork-once
+tests/userprog/fork-multiple
+tests/userprog/fork-recursive
+tests/userprog/fork-read
+tests/userprog/fork-close
+tests/userprog/fork-boundary
+tests/userprog/wait-simple
+tests/userprog/wait-twice
+tests/userprog/wait-killed
+tests/userprog/exec-boundary
+tests/userprog/exec-read
+tests/userprog/multi-recurse
+tests/userprog/multi-child-fd
+tests/userprog/rox-child
+tests/userprog/rox-multichild
+tests/userprog/no-vm/multi-oom
+```
+
+`wait-bad-pid`는 로컬 테스트 파일 기준으로 `fork()`를 호출하지 않고 잘못된 pid에 대한 `wait()`만 확인하므로 제외하지 않았다.
+
+## exec 기본 테스트만 실행
+
+`exec-once`, `exec-arg` 두 테스트만 Project 3 빌드로 확인하려면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make p2-exec-basic-check
+```
+
+결과 파일만 갱신하고 요약을 만들려면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make p2-exec-basic-results
+```
+
+요약은 `pintos/vm/build/selected-results`에 생긴다.
+
+## Extra 2, dup2 테스트까지 포함
+
+Project 2 extra 테스트인 `dup2`까지 포함하려면 `TEST_SUBDIRS`에 `tests/userprog/dup2`를 추가하고, user program 컴파일 플래그에 `-DEXTRA2`를 준다.
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make check \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/userprog/dup2 tests/threads" \
+  TDEFINE=-DEXTRA2
+```
+
+`TDEFINE`은 `pintos/Makefile.userprog`에서 user program 컴파일 옵션에 붙는다.
+
+## grade 형식으로 보고 싶을 때
+
+`check`는 pass/FAIL 요약을 보여준다. Pintos grading 형식의 `grade` 파일까지 만들고 싶으면 `GRADING_FILE`도 Project 2 기준으로 덮어쓴다.
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make grade \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads" \
+  GRADING_FILE='$(SRCDIR)/tests/userprog/Grading.no-extra'
+```
+
+extra2까지 포함한다면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make grade \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/userprog/dup2 tests/threads" \
+  TDEFINE=-DEXTRA2 \
+  GRADING_FILE='$(SRCDIR)/tests/userprog/Grading.extra'
+```
+
+`grade` 결과 파일은 `pintos/vm/build/grade`에 생긴다.
+
+## 결과 확인 위치
+
+전체 요약:
+
+```bash
+cat /Users/sisu/Projects/jungle/pintos/pintos/vm/build/results
+```
+
+단일 테스트 출력 예시:
+
+```bash
+cat /Users/sisu/Projects/jungle/pintos/pintos/vm/build/tests/userprog/args-none.output
+cat /Users/sisu/Projects/jungle/pintos/pintos/vm/build/tests/userprog/args-none.errors
+cat /Users/sisu/Projects/jungle/pintos/pintos/vm/build/tests/userprog/args-none.result
+```
+
+## 주의사항
+
+- `cd pintos/userprog && make check`는 Project 2 빌드로 Project 2 테스트를 돌리는 명령이다. Project 3 VM 코드까지 포함한 커널로 확인하려면 `pintos/vm`에서 실행해야 한다.
+- `cd pintos/vm && make check`만 실행하면 `vm/Make.vars` 기본값 때문에 Project 3 테스트까지 포함된다.
+- Project 3 빌드로 Project 2 테스트를 돌릴 때는 `TEST_SUBDIRS`만 Project 2 목록으로 제한한다.
+- 기존 `pintos/vm/build` 산출물이 꼬였다고 의심되면 사용자가 직접 `cd pintos/vm && make clean` 후 다시 위 명령을 실행하면 된다.

--- a/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
+++ b/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
@@ -1,0 +1,165 @@
+# Project 3 빌드로 Project 2 테스트 실행 가이드
+
+## 목적
+
+Project 3 VM 구현이 들어간 커널, 즉 `pintos/vm` 빌드 결과로 Project 2 테스트 묶음을 돌리는 방법을 정리한다.
+
+핵심은 `pintos/userprog`에서 실행하지 않고 `pintos/vm`에서 실행하되, 테스트 목록만 Project 2 기준으로 덮어쓰는 것이다.
+
+## 기준 파일
+
+- `pintos/vm/Make.vars`
+  - Project 3 빌드는 `KERNEL_SUBDIRS`에 `vm`을 포함한다.
+  - 기본 `TEST_SUBDIRS`에는 `tests/vm`이 들어 있어 그냥 `make check`를 하면 Project 3 테스트까지 같이 돈다.
+- `pintos/userprog/Make.vars`
+  - Project 2 기본 테스트 목록은 `tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads`이다.
+- `pintos/Makefile.kernel`
+  - 상위 디렉터리에서 `make check`를 실행하면 `build/` 디렉터리를 준비한 뒤 `build` 안에서 실제 테스트를 실행한다.
+- `pintos/tests/Make.tests`
+  - `TEST_SUBDIRS`에 들어간 테스트 디렉터리의 `Make.tests`만 포함해서 테스트 목록을 만든다.
+
+## 전체 Project 2 테스트 실행
+
+저장소 바깥 루트가 `/Users/sisu/Projects/jungle/pintos`일 때:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make check TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads"
+```
+
+이 명령은 다음 성질을 가진다.
+
+- 빌드 위치는 `pintos/vm`이므로 `vm/Make.vars`의 Project 3 커널 구성을 사용한다.
+- `KERNEL_SUBDIRS`에는 `vm`이 포함된 상태로 유지된다.
+- `TEST_SUBDIRS`만 Project 2의 기본 테스트 목록으로 바뀐다.
+- 결과는 `pintos/vm/build/results`에 요약된다.
+- 각 테스트별 출력은 `pintos/vm/build/tests/.../*.output`, `*.errors`, `*.result`에 생긴다.
+
+## 단일 테스트만 실행
+
+예를 들어 `args-none` 하나만 Project 3 빌드로 확인하려면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make build/tests/userprog/args-none.result \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads"
+```
+
+`no-vm`의 `multi-oom`만 확인하려면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make build/tests/userprog/no-vm/multi-oom.result \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads"
+```
+
+상위 `pintos/vm`에서 `build/...` 형태로 호출하는 이유는 `Makefile.kernel`이 필요한 `build/tests/...` 디렉터리를 먼저 만들어 주기 때문이다. `pintos/vm/build`에 직접 들어가서 실행하면, 처음 실행하는 테스트 하위 디렉터리가 없어서 실패할 수 있다.
+
+## fork 제외 Project 2 테스트만 실행
+
+이 저장소에는 Project 3 빌드에서 Project 2 기본 테스트 묶음을 돌리되, `fork()` syscall에 직접 의존하는 테스트를 제외하는 편의 타깃을 추가했다.
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make p2-nofork-check
+```
+
+결과 파일만 갱신하고 요약 파일을 만들고 싶으면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make p2-nofork-results
+```
+
+요약은 `pintos/vm/build/selected-results`에 생긴다.
+
+파일 시스템 base 테스트까지 섞지 않고 userprog 중심으로만 보고 싶으면 다음 타깃을 쓴다.
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make p2-user-nofork-check
+```
+
+이 타깃은 `tests/userprog`와 `tests/threads`만 포함하고, `tests/filesys/base`와 `tests/userprog/no-vm`은 제외한다.
+
+제외되는 테스트는 다음 항목이다.
+
+```text
+tests/userprog/fork-once
+tests/userprog/fork-multiple
+tests/userprog/fork-recursive
+tests/userprog/fork-read
+tests/userprog/fork-close
+tests/userprog/fork-boundary
+tests/userprog/wait-simple
+tests/userprog/wait-twice
+tests/userprog/wait-killed
+tests/userprog/exec-boundary
+tests/userprog/exec-read
+tests/userprog/multi-recurse
+tests/userprog/multi-child-fd
+tests/userprog/rox-child
+tests/userprog/rox-multichild
+tests/userprog/no-vm/multi-oom
+```
+
+`wait-bad-pid`는 로컬 테스트 파일 기준으로 `fork()`를 호출하지 않고 잘못된 pid에 대한 `wait()`만 확인하므로 제외하지 않았다.
+
+## Extra 2, dup2 테스트까지 포함
+
+Project 2 extra 테스트인 `dup2`까지 포함하려면 `TEST_SUBDIRS`에 `tests/userprog/dup2`를 추가하고, user program 컴파일 플래그에 `-DEXTRA2`를 준다.
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make check \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/userprog/dup2 tests/threads" \
+  TDEFINE=-DEXTRA2
+```
+
+`TDEFINE`은 `pintos/Makefile.userprog`에서 user program 컴파일 옵션에 붙는다.
+
+## grade 형식으로 보고 싶을 때
+
+`check`는 pass/FAIL 요약을 보여준다. Pintos grading 형식의 `grade` 파일까지 만들고 싶으면 `GRADING_FILE`도 Project 2 기준으로 덮어쓴다.
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make grade \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads" \
+  GRADING_FILE='$(SRCDIR)/tests/userprog/Grading.no-extra'
+```
+
+extra2까지 포함한다면:
+
+```bash
+cd /Users/sisu/Projects/jungle/pintos/pintos/vm
+make grade \
+  TEST_SUBDIRS="tests/userprog tests/filesys/base tests/userprog/no-vm tests/userprog/dup2 tests/threads" \
+  TDEFINE=-DEXTRA2 \
+  GRADING_FILE='$(SRCDIR)/tests/userprog/Grading.extra'
+```
+
+`grade` 결과 파일은 `pintos/vm/build/grade`에 생긴다.
+
+## 결과 확인 위치
+
+전체 요약:
+
+```bash
+cat /Users/sisu/Projects/jungle/pintos/pintos/vm/build/results
+```
+
+단일 테스트 출력 예시:
+
+```bash
+cat /Users/sisu/Projects/jungle/pintos/pintos/vm/build/tests/userprog/args-none.output
+cat /Users/sisu/Projects/jungle/pintos/pintos/vm/build/tests/userprog/args-none.errors
+cat /Users/sisu/Projects/jungle/pintos/pintos/vm/build/tests/userprog/args-none.result
+```
+
+## 주의사항
+
+- `cd pintos/userprog && make check`는 Project 2 빌드로 Project 2 테스트를 돌리는 명령이다. Project 3 VM 코드까지 포함한 커널로 확인하려면 `pintos/vm`에서 실행해야 한다.
+- `cd pintos/vm && make check`만 실행하면 `vm/Make.vars` 기본값 때문에 Project 3 테스트까지 포함된다.
+- Project 3 빌드로 Project 2 테스트를 돌릴 때는 `TEST_SUBDIRS`만 Project 2 목록으로 제한한다.
+- 기존 `pintos/vm/build` 산출물이 꼬였다고 의심되면 사용자가 직접 `cd pintos/vm && make clean` 후 다시 위 명령을 실행하면 된다.

--- a/docs/ai/004_이번_주_branch_fix_로그_정리.md
+++ b/docs/ai/004_이번_주_branch_fix_로그_정리.md
@@ -1,0 +1,189 @@
+# 이번 주 branch fix 로그 정리
+
+작성 기준: 2026-05-13, `git fetch origin --prune` 이후 현재 로컬 저장소에서 확인 가능한 refs.
+
+검토 범위는 2026-05-11 00:00 이후의 local branch와 `origin/*` remote branch다. 테스트는 직접 실행하지 않았고, 커밋 메시지, 브랜치명, 변경 파일, revert/debug/unfixed 기록을 근거로 정리했다. 따라서 아래의 "확정"은 커밋 메시지에 커널 패닉, test fail, unfixed, revert 등 직접 증거가 있는 경우이고, "의심"은 fix/debug가 몰린 위치를 기준으로 한 추정이다.
+
+## 요약
+
+가장 의심도가 높은 흐름은 세 군데다.
+
+1. `issue-317-exec-test-fail`: 브랜치명 자체가 exec test fail이고, `pintos/userprog/syscall.c`의 사용자 버퍼 검증, `SYS_EXEC` 처리, read/write 검증 방향을 짧은 시간에 여러 번 수정했다.
+2. `issue-306-lazy_load_segment` 및 여기서 파생된 local `issue-311-vm_stack_page_allocation`: `spt_find_page`, `vm_try_handle_fault`, stack setup, SPT cleanup에서 커널 패닉 또는 page fault 처리 실패를 직접 언급한 커밋이 있다.
+3. `issue-309-hash_spt` 및 `origin/revert-312-issue-309-hash_spt`: hash 기반 SPT 구현이 PR merge 후 revert 되었고, hash key, dummy page, malloc 실패 처리 fix가 이어졌다.
+
+fix/debug/revert 커밋이 몰린 파일은 다음 순서다.
+
+| 파일 | 문제성 커밋 수 | 의심 영역 |
+| --- | ---: | --- |
+| `pintos/vm/vm.c` | 18 | SPT 조회/삽입/삭제, page fault, frame claim |
+| `pintos/userprog/syscall.c` | 12 | syscall 인자 검증, read/write 버퍼 검증, `SYS_EXEC` |
+| `pintos/userprog/process.c` | 7 | lazy load, stack setup, process load 흐름 |
+| `pintos/lib/kernel/hash.c` | 5 | SPT hash key/compare 구현 위치와 방식 |
+
+## branch별 확인 포인트
+
+| branch | 현재 head | 문제 증거 | 확인할 커밋 |
+| --- | --- | --- | --- |
+| `issue-317-exec-test-fail`, `origin/issue-317-exec-test-fail` | `3c1fcfb` | 확정: branch명 test fail, `unfixed` 커밋, debug/fix 연쇄 | `3c1fcfb`, `8e82a39`, `b2d0861`, `47b47b2`, `d2cf410`, `b933c71`, `dca62f5` |
+| `issue-306-lazy_load_segment`, `origin/issue-306-lazy_load_segment` | `7cbbbbc` | 확정: SPT 미매핑 VA 커널 패닉, SPT cleanup 오류 | `7cbbbbc`, `c444a36`, `d7be070`, `974e100`, `41f62c5` |
+| `issue-309-hash_spt`, `origin/issue-309-hash_spt` | `28af638` | 확정/강한 의심: hash SPT 구현 후 revert branch 존재, SPT 조회/키 계산 fix 다수 | `28af638`, `974e100`, `41f62c5`, `d3cb66d`, `1e1146f`, `5398ca4` |
+| `origin/revert-312-issue-309-hash_spt` | `9742bbd` | 확정: PR #312의 hash 기반 SPT 구현 revert | `9742bbd` |
+| `issue-307-exec-lazy-loading`, `origin/issue-307-exec-lazy-loading` | `4d053f2` | 의심: uninit/page claim 실패 시 자원 해제 책임을 수정했다가 revert 후 재수정 | `4d053f2`, `638c615`, `a87f2e3`, `03a157c` |
+| local `issue-311-vm_stack_page_allocation` | `7e9f0c3` | 의심: local에 VM/stack 관련 커밋이 많이 쌓였고, 커널 패닉 fix를 포함한다 | `7e9f0c3`, `d7be070`, `c444a36`, `28af638` |
+| `origin/issue-311-vm_stack_page_allocation` | `1b19ab9` | 낮음: remote에는 변수명 refactor만 있음 | `1b19ab9` |
+| `origin/issue-308-uninitanon-initializer` | `47f054a` | 낮음: initializer ASSERT/type 변경, 명시적 fail/fix 메시지는 없음 | `47f054a`, `35338e3` |
+| `issue-316-fix_exec`, `origin/issue-316-fix_exec` | `d16aba8` | 낮음: 테스트 방법/Makefile 문서화 성격 | `d16aba8`, `7e9f0c3` |
+| `origin/main` | `9815445` | 낮음: docs commit만 확인 | `9815445` |
+
+참고: local `issue-311-vm_stack_page_allocation`은 현재 upstream이 `origin/issue-306-lazy_load_segment`로 잡혀 있다. remote `origin/issue-311-vm_stack_page_allocation`과는 내용이 크게 다르므로, 팀원이 branch 기준으로 확인할 때 이 점을 먼저 확인하는 편이 좋다.
+
+## 사고 로그 후보
+
+### 1. exec test fail 및 syscall 사용자 버퍼 검증
+
+- branch: `issue-317-exec-test-fail`, `origin/issue-317-exec-test-fail`
+- 주요 파일: `pintos/userprog/syscall.c`, 일부 `pintos/vm/vm.c`
+- 확정 근거: branch명에 `exec-test-fail`, `dca62f5`의 `unfixed`, debug 커밋 2개, fix 커밋 다수
+
+확인할 커밋:
+
+| 커밋 | 증상/문제 | 해결 방향 |
+| --- | --- | --- |
+| `dca62f5` | "unfixed" checkpoint. 퇴근 전 미해결 상태를 올린 기록 | 이후 커밋에서 syscall 검증과 page fault 처리를 계속 수정 |
+| `8e82a39` | `SYS_EXEC` case가 다음 case로 떨어질 수 있는 switch 흐름 | `SYS_EXEC` 처리 뒤 break 추가 |
+| `b933c71` | page fault 처리 중 NULL 주소나 SPT lookup 실패를 정상 실패로 다루지 못함 | `vm_try_handle_fault`에서 NULL/fault 불가 조건을 false로 반환 |
+| `d2cf410` | non-present PTE 상태에서 user bit 검사 조건이 맞지 않음 | present 여부와 user 영역 검사를 분리하도록 조건 수정 |
+| `47b47b2` | `validate_user_read/write` 호출 인자 오류 | read/write 검증 함수로 넘기는 인자 정정 |
+| `b2d0861` | read/write syscall에서 이미 내부 검증이 있는데 중복 검증 수행 | 중복 validate 제거 |
+| `3c1fcfb` | read/write 접근 방향을 거꾸로 넘긴 최종 오류 | `validate_user_read`와 `validate_user_write`의 접근 방향 정상화 |
+
+판단: 실제 문제는 단일 원인이라기보다 `exec` syscall 주변에서 사용자 포인터 검증, lazy page claim, switch 흐름이 함께 흔들린 것으로 보인다. 팀원이 확인할 때는 `3c1fcfb`만 보지 말고 `dca62f5..3c1fcfb` 범위를 같이 보는 것이 좋다.
+
+### 2. SPT 미매핑 VA에서 커널 패닉
+
+- branch: `issue-306-lazy_load_segment`, local `issue-311-vm_stack_page_allocation`, `origin/issue-317-exec-test-fail`에도 포함
+- 주요 파일: `pintos/vm/vm.c`
+- 확정 근거: `c444a36` 커밋 메시지가 "커널 패닉 발생하던 문제 해결"을 직접 언급
+
+확인할 커밋:
+
+| 커밋 | 증상/문제 | 해결 방향 |
+| --- | --- | --- |
+| `c444a36` | VA가 SPT에 매핑되어 있지 않은데 예외처리 없이 hash lookup 결과를 사용해 커널 패닉 | `spt_find_page`에서 lookup 실패 시 NULL 반환 |
+| `b933c71` | page fault 처리에서도 NULL 주소/SPT miss를 실패로 처리해야 함 | `vm_try_handle_fault`에서 fault 처리 불가 조건을 false로 반환 |
+| `974e100` | `spt_find_page`의 조회용 dummy page를 동적 할당하던 문제 | 조회용 객체 관리 방식을 정리해 불필요한 할당/해제 위험 축소 |
+| `41f62c5` | SPT hash key를 VA 값이 아니라 VA가 가리키는 메모리처럼 다룰 수 있는 구현 | page-aligned user virtual address 값을 key로 쓰도록 수정 |
+
+판단: 이 라인은 SPT 조회 실패를 정상적인 "page 없음"으로 처리하지 못한 것이 핵심 사고다. hash key 계산 오류와 dummy page 관리 방식도 같은 영역의 전조로 볼 수 있다.
+
+### 3. SPT cleanup 누락
+
+- branch: `issue-306-lazy_load_segment`, `origin/issue-306-lazy_load_segment`
+- 주요 파일: `pintos/vm/vm.c`, `pintos/include/threads/thread.h`, `pintos/userprog/process.c`
+- 확정 근거: `7cbbbbc` 커밋 메시지가 "spt 청소 안 해줘서 생기던 오류 해결"을 직접 언급
+
+확인할 커밋:
+
+| 커밋 | 증상/문제 | 해결 방향 |
+| --- | --- | --- |
+| `7cbbbbc` | thread/process 종료 시 SPT에 남은 page/frame 정리가 되지 않는 오류 | `supplemental_page_table_kill` 및 hash destroy 흐름 추가 |
+
+주의: 이 커밋에는 cleanup 구현 외에 debug `printf`가 포함되어 있다. 팀원이 실제 최종 코드로 가져갈 때는 debug 출력이 남아 있는지 별도로 확인해야 한다.
+
+### 4. hash 기반 SPT 구현 revert
+
+- branch: `issue-309-hash_spt`, `origin/issue-309-hash_spt`, `origin/revert-312-issue-309-hash_spt`
+- 주요 파일: `pintos/vm/vm.c`, `pintos/lib/kernel/hash.c`, `pintos/include/vm/vm.h`
+- 확정 근거: `origin/revert-312-issue-309-hash_spt`가 존재하고 `9742bbd`가 PR #312의 hash 기반 SPT 구현을 revert
+
+확인할 커밋:
+
+| 커밋 | 증상/문제 | 해결 방향 |
+| --- | --- | --- |
+| `9742bbd` | hash 기반 supplemental page table 구현 전체가 revert 됨 | `pintos/vm/vm.c`, `pintos/lib/kernel/hash.c`, `pintos/include/vm/vm.h`의 hash SPT 변경 제거 |
+| `41f62c5` | hash key 계산이 VA 값 기준이 아니어서 잘못된 메모리를 읽을 수 있음 | SPT key를 page-aligned VA 값 기준으로 계산 |
+| `5398ca4` | `spt_find_page`에서 hash miss를 NULL로 처리하지 못함 | hash miss 시 NULL 반환 및 조회용 객체 정리 |
+| `1e1146f` | `hash_insert`에 넘기는 대상이 잘못됨 | SPT 내부 hash table을 삽입 대상으로 넘기도록 수정 |
+| `d3cb66d` | `vm_alloc_page_with_initializer` 성공 경로 반환 및 실패 정리 누락 | 성공 시 true 반환, 실패 시 page 정리 |
+| `28af638` | malloc 실패 처리 누락 | 할당 실패 시 실패 반환/정리 흐름 추가 |
+
+판단: 이 영역은 fix가 많은 정도를 넘어 revert branch가 남아 있으므로, 실제 사고 가능성이 매우 높다. 팀원이 보려면 `issue-309-hash_spt`의 초기 hash 함수 커밋부터 `9742bbd` revert까지 보는 것이 가장 빠르다.
+
+### 5. lazy loading의 자원 해제 책임
+
+- branch: `issue-307-exec-lazy-loading`, `origin/issue-307-exec-lazy-loading`
+- 주요 파일: `pintos/vm/uninit.c`, `pintos/vm/vm.c`, `pintos/userprog/process.c`
+- 근거: fix 이후 revert, 다시 fix가 이어진 흐름
+
+확인할 커밋:
+
+| 커밋 | 증상/문제 | 해결 방향 |
+| --- | --- | --- |
+| `03a157c` | `uninit_initialize` 실패 시 자원 정리 책임을 단일화하려는 fix | 실패 처리 책임을 한쪽으로 모으는 방향 |
+| `a87f2e3` | 위 fix를 revert | 책임 위치가 맞지 않았거나 부작용이 있었던 것으로 추정 |
+| `638c615` | `process.c` 쪽 자원 해제 책임 조정 | 다른 위치의 해제 제거 |
+| `4d053f2` | 최종적으로 자원 해제 책임을 `vm_do_claim_page` 쪽으로 넘김 | claim 실패 처리 경로에서 정리하도록 조정 |
+
+판단: 명시적인 kernel panic/test fail 메시지는 없지만, 실패 경로에서 double free, leak, use-after-free 류 문제가 있었을 가능성이 있다. 단정하려면 해당 시점의 실패 로그가 필요하다.
+
+### 6. setup_stack 실패
+
+- branch: local `issue-311-vm_stack_page_allocation`, `issue-306-lazy_load_segment` 계열
+- 주요 파일: `pintos/userprog/process.c`
+- 근거: `d7be070` 커밋 메시지
+
+확인할 커밋:
+
+| 커밋 | 증상/문제 | 해결 방향 |
+| --- | --- | --- |
+| `d7be070` | `setup_stack`이 무조건 false를 반환 | 성공/실패 반환 흐름 수정. 단, 커밋 메시지상 추가 예외처리 필요 |
+
+판단: stack setup이 항상 실패하면 exec/load 계열 테스트가 연쇄적으로 실패할 수 있다. 이 커밋은 `issue-317-exec-test-fail`의 exec 실패 흐름과도 연결해서 보는 것이 좋다.
+
+## 이번 주 refs 상태
+
+현재 refs 기준으로 2026-05-11 이후 커밋이 확인된 branch는 다음과 같다.
+
+| ref | 이번 주 reachable commit 수 | 비고 |
+| --- | ---: | --- |
+| `issue-317-exec-test-fail` / `origin/issue-317-exec-test-fail` | 66 | exec test fail fix 라인. 조상 커밋 포함 |
+| `issue-306-lazy_load_segment` / `origin/issue-306-lazy_load_segment` | 51 | lazy loading/SPT fix 라인 |
+| local `issue-311-vm_stack_page_allocation` | 50 | local 작업이 많음. upstream 설정이 `origin/issue-306-lazy_load_segment`로 되어 있음 |
+| `issue-309-hash_spt` / `origin/issue-309-hash_spt` | 38 | hash SPT fix 라인 |
+| `origin/revert-312-issue-309-hash_spt` | 38 | hash SPT revert 라인 |
+| `issue-307-exec-lazy-loading` / `origin/issue-307-exec-lazy-loading` | 19 | exec lazy loading/resource ownership |
+| `origin/issue-308-uninitanon-initializer` | 3 | initializer 타입/ASSERT 변경 |
+| `issue-316-fix_exec` / `origin/issue-316-fix_exec` | 2 | 테스트 방법 문서화 |
+| `origin/main` | 1 | docs commit |
+
+`git fetch origin --prune` 중 삭제된 remote refs도 있었다: `origin/develop`, `origin/feature/p1-alarm-clock`, `origin/feature/p1-priority-scheduling`, `origin/merge/ys-ts-into-develop`, `origin/pr-310`. 현재 저장소의 remote ref로는 더 이상 남아 있지 않으므로 이 문서의 branch별 표에서는 제외했다.
+
+## 팀원이 직접 확인할 때 쓸 명령
+
+커밋 하나의 변경 요약:
+
+```bash
+git show --stat <commit>
+```
+
+커밋 전후 흐름 확인:
+
+```bash
+git log --oneline --decorate --date=short --since='2026-05-11 00:00' <branch>
+```
+
+특정 커밋이 어느 branch에 포함되어 있는지 확인:
+
+```bash
+git branch --all --contains <commit>
+```
+
+문제성 커밋만 빠르게 보기:
+
+```bash
+git log --all --since='2026-05-11 00:00' --regexp-ignore-case \
+  --grep='fix\|debug\|unfixed\|revert\|fail\|panic\|오류\|문제\|실패' \
+  --date=iso-strict --pretty=format:'%h %ad %D %s'
+```
+

--- a/pintos/docs/rules.md
+++ b/pintos/docs/rules.md
@@ -64,7 +64,85 @@ git rebase develop
 
 충돌이 어렵거나 shared file 충돌이면 혼자 해결하지 말고 최소 1명과 함께 본다.
 
-## 2. Commit 규칙
+## 2. Issue 규칙
+
+Issue는 작업을 시작하기 전에 목표, 범위, 완료 기준을 팀원이 같은 기준으로 이해하기 위해 작성한다. 구현 중 발견한 bug, 추가 확인이 필요한 요구사항, 리팩토링 작업도 별도 issue로 남긴다.
+
+Issue 제목 형식:
+
+```text
+<type>(<scope>): <summary>
+```
+
+type은 commit 규칙의 type을 그대로 사용한다.
+
+Issue 제목 예시:
+
+```text
+feat(timer): implement alarm clock without busy waiting
+feat(thread): add priority donation for nested locks
+fix(synch): wake highest-priority waiter first
+refactor(thread): split priority recalculation helper
+docs(project1): organize mlfqs debugging notes
+```
+
+Issue 작성 원칙:
+
+- 하나의 issue는 하나의 기능, 하나의 bug, 하나의 조사 주제만 다룬다.
+- 구현 범위와 제외 범위를 함께 적는다.
+- 관련 reference, 테스트 파일, 실패 로그가 있으면 링크나 경로를 남긴다.
+- 목표 테스트와 회귀 테스트 후보를 구분해서 적는다.
+- 작업 전 가설은 단정하지 않고 "확인할 것"으로 적는다.
+- 구현 방향을 논의할 수는 있지만, 테스트 이름 기반 하드코딩이나 임시 우회는 완료 기준으로 삼지 않는다.
+- issue가 커지면 선행 issue와 후속 issue로 나누고 의존 관계를 본문에 적는다.
+- issue를 닫기 전에 연결된 PR, 통과한 테스트, 남은 위험 요소를 확인한다.
+
+Issue 본문 템플릿:
+
+````md
+## 배경
+
+-
+
+## 작업 범위
+
+-
+
+## 제외 범위
+
+-
+
+## 기준 자료
+
+- `pintos/docs/reference/...`
+- `pintos/tests/...`
+
+## 목표 테스트
+
+- [ ] `make tests/<path>/<test-name>.result`
+
+## 회귀 테스트 후보
+
+- [ ] `make tests/<path>/<test-name>.result`
+
+## 확인할 것
+
+-
+
+## 완료 기준
+
+- [ ] 구현 범위가 코드 또는 문서에 반영됨
+- [ ] 목표 테스트 통과 여부를 확인함
+- [ ] 관련 회귀 테스트 영향 여부를 확인함
+- [ ] debug print와 임시 코드가 남아 있지 않음
+- [ ] PR 본문에 issue 번호를 연결함
+
+## 위험 요소
+
+-
+````
+
+## 3. Commit 규칙
 
 형식:
 
@@ -121,7 +199,7 @@ commit 단위 원칙:
 - commit은 "언제 올릴지"보다 "무슨 변경을 묶는지"가 더 중요하다. 테스트 이름 하나보다 코드상 의미 단위를 우선한다.
 - 테스트 통과 여부만 적는 commit보다, 왜 그 변경이 필요한지 드러나는 summary를 우선한다.
 
-## 3. PR 규칙
+## 4. PR 규칙
 
 PR 제목 형식:
 
@@ -215,7 +293,7 @@ paste result here
 - [ ] 복잡한 invariant는 주석 또는 문서에 설명
 ````
 
-## 4. 리뷰 방식
+## 5. 리뷰 방식
 
 PR 작성자를 제외한 두 명이 함께 검토한다.
 
@@ -250,7 +328,7 @@ PR 작성자를 제외한 두 명이 함께 검토한다.
 [질문/제안] D 방식으로 확인하거나 수정하는 것은 어떨까요?
 ```
 
-## 5. 코드 컨벤션
+## 6. 코드 컨벤션
 
 - 기존 PintOS 코드 스타일을 우선한다.
 - 새 함수 이름과 코드 구조는 현재 `develop`에 올라간 주변 코드 스타일을 먼저 따른다.

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -1,5 +1,4 @@
 #define VM
-
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H
 
@@ -29,7 +28,7 @@ enum thread_status {
 typedef int tid_t;
 #define TID_ERROR ((tid_t) -1)          /* tid_t의 오류 값. */
 
-#ifdef USERPROG
+// #ifdef USERPROG
 /* parent와 child가 공유하는 process lifecycle record.
  * record 객체는 struct thread 안에 값으로 넣지 않고, process.c에서
  * malloc()으로 별도 할당해 parent/child가 pointer로 공유한다. */
@@ -45,7 +44,7 @@ struct child_status {
 };
 
 struct file;
-#endif
+// #endif
 
 /* thread priority(스레드 우선순위). */
 #define PRI_MIN 0                       /* 가장 낮은 priority. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -123,7 +123,7 @@ struct thread {
 	struct list donations;							/* 이 thread에게 priority를 기부한 donor thread들의 목록. */
 	struct lock *wait_lock;							/* 이 thread가 현재 기다리는 lock. 기다리는 lock이 없으면 NULL. */
 
-#ifdef USERPROG
+// #ifdef USERPROG
 	/* userprog/process.c가 소유한다. */
 	uint64_t *pml4;                     /* PML4 테이블 */
 	int exit_status;										/* syscall exit status */
@@ -134,7 +134,7 @@ struct thread {
 	struct file *running_file;					/* 현재 thread가 load 하고 실행하고 있는 file */
 	struct file *fd_table[FD_MAX];     	/* 프로세스별 파일 디스크립터 테이블 */
 	int next_fd;                       	/* 다음 할당 후보 fd */
-#endif
+// #endif
 #ifdef VM
 	/* thread가 소유한 전체 virtual memory에 대한 테이블. */
 	struct supplemental_page_table spt;

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -1,4 +1,4 @@
-#define VM
+// #define VM
 
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -47,6 +47,7 @@ struct page {
 	const struct page_operations *operations;
 	void *va;              /* user space 기준 주소 */
 	struct frame *frame;   /* frame을 가리키는 역참조 */
+	bool writable;
 
 	/* 타입별 데이터는 union에 묶여 있다.
 	 * 각 함수는 현재 union을 자동으로 감지한다. */

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -48,6 +48,8 @@ struct page {
 	void *va;              /* user space 기준 주소 */
 	struct frame *frame;   /* frame을 가리키는 역참조 */
 
+	struct hash_elem hash_elem;
+
 	/* 타입별 데이터는 union에 묶여 있다.
 	 * 각 함수는 현재 union을 자동으로 감지한다. */
 	union {
@@ -86,6 +88,7 @@ struct page_operations {
  * 이 struct의 설계를 특정 방식으로 강제하고 싶지는 않다.
  * 설계는 전부 여러분에게 달려 있다. */
 struct supplemental_page_table {
+	struct hash table;
 };
 
 #include "threads/thread.h"

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -34,7 +34,7 @@ less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
 	struct page* pa = hash_entry (a, struct page, hash_elem);
 	struct page* pb = hash_entry (b, struct page, hash_elem);
 
-	return pg_round_down(pa->va < pb->va);
+	return pg_round_down(pa->va) < pg_round_down(pb->va);
 }
 
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -7,6 +7,7 @@
 #include "hash.h"
 #include "../debug.h"
 #include "threads/malloc.h"
+#include "/workspaces/pintos/pintos/include/vm/vm.h"
 
 #define list_elem_to_hash_elem(LIST_ELEM)                       \
 	list_entry(LIST_ELEM, struct hash_elem, list_elem)
@@ -17,6 +18,13 @@ static struct hash_elem *find_elem (struct hash *, struct list *,
 static void insert_elem (struct hash *, struct list *, struct hash_elem *);
 static void remove_elem (struct hash *, struct hash_elem *);
 static void rehash (struct hash *);
+
+uint64_t
+hash_func (const struct hash_elem *e, void* aux) {
+	struct page* page = hash_entry (e, struct page, hash_elem);
+
+	return hash_bytes (page->va, sizeof page->va);
+}
 
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를
    초기화합니다. */

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -26,6 +26,14 @@ hash_func (const struct hash_elem *e, void* aux) {
 	return hash_bytes (page->va, sizeof page->va);
 }
 
+bool
+less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
+	struct page* pa = hash_entry (a, struct page, hash_elem);
+	struct page* pb = hash_entry (a, struct page, hash_elem);
+
+	return pa->va < pb->va;
+}
+
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를
    초기화합니다. */
 bool

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -19,17 +19,19 @@ static void insert_elem (struct hash *, struct list *, struct hash_elem *);
 static void remove_elem (struct hash *, struct hash_elem *);
 static void rehash (struct hash *);
 
+/* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
 uint64_t
 hash_func (const struct hash_elem *e, void* aux) {
 	struct page* page = hash_entry (e, struct page, hash_elem);
 
-	return hash_bytes (page->va, sizeof page->va);
+	return hash_bytes (&page->va, sizeof page->va);
 }
 
+/* 두 page의 key인 va 값을 비교한다. */
 bool
 less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
 	struct page* pa = hash_entry (a, struct page, hash_elem);
-	struct page* pb = hash_entry (a, struct page, hash_elem);
+	struct page* pb = hash_entry (b, struct page, hash_elem);
 
 	return pa->va < pb->va;
 }

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -7,7 +7,8 @@
 #include "hash.h"
 #include "../debug.h"
 #include "threads/malloc.h"
-#include "/workspaces/pintos/pintos/include/vm/vm.h"
+#include "vm/vm.h"
+#include "threads/vaddr.h"
 
 #define list_elem_to_hash_elem(LIST_ELEM)                       \
 	list_entry(LIST_ELEM, struct hash_elem, list_elem)
@@ -24,7 +25,7 @@ uint64_t
 hash_func (const struct hash_elem *e, void* aux) {
 	struct page* page = hash_entry (e, struct page, hash_elem);
 
-	return hash_bytes (&page->va, sizeof page->va);
+	return hash_bytes (pg_round_down(page->va), sizeof page->va);
 }
 
 /* 두 page의 key인 va 값을 비교한다. */
@@ -33,7 +34,7 @@ less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
 	struct page* pa = hash_entry (a, struct page, hash_elem);
 	struct page* pb = hash_entry (b, struct page, hash_elem);
 
-	return pa->va < pb->va;
+	return pg_round_down(pa->va < pb->va);
 }
 
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를

--- a/pintos/lib/kernel/hash.c
+++ b/pintos/lib/kernel/hash.c
@@ -7,8 +7,6 @@
 #include "hash.h"
 #include "../debug.h"
 #include "threads/malloc.h"
-#include "vm/vm.h"
-#include "threads/vaddr.h"
 
 #define list_elem_to_hash_elem(LIST_ELEM)                       \
 	list_entry(LIST_ELEM, struct hash_elem, list_elem)
@@ -20,22 +18,7 @@ static void insert_elem (struct hash *, struct list *, struct hash_elem *);
 static void remove_elem (struct hash *, struct hash_elem *);
 static void rehash (struct hash *);
 
-/* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
-uint64_t
-hash_func (const struct hash_elem *e, void* aux) {
-	struct page* page = hash_entry (e, struct page, hash_elem);
 
-	return hash_bytes (pg_round_down(page->va), sizeof page->va);
-}
-
-/* 두 page의 key인 va 값을 비교한다. */
-bool
-less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
-	struct page* pa = hash_entry (a, struct page, hash_elem);
-	struct page* pb = hash_entry (b, struct page, hash_elem);
-
-	return pg_round_down(pa->va) < pg_round_down(pb->va);
-}
 
 /* 보조 데이터 AUX가 주어졌을 때, HASH를 사용해 해시 값을 계산하고 LESS를 사용해 해시 요소를 비교하도록 해시 테이블 H를
    초기화합니다. */

--- a/pintos/tests/Make.tests
+++ b/pintos/tests/Make.tests
@@ -10,6 +10,9 @@ OUTPUTS = $(addsuffix .output,$(TESTS) $(EXTRA_GRADES))
 ERRORS = $(addsuffix .errors,$(TESTS) $(EXTRA_GRADES))
 RESULTS = $(addsuffix .result,$(TESTS) $(EXTRA_GRADES))
 SELECTED_TESTS = $(filter-out $(EXCLUDE_TESTS),$(TESTS) $(EXTRA_GRADES))
+ifdef INCLUDE_TESTS
+SELECTED_TESTS = $(INCLUDE_TESTS)
+endif
 SELECTED_RESULTS = $(addsuffix .result,$(SELECTED_TESTS))
 
 ifdef PROGS

--- a/pintos/tests/Make.tests
+++ b/pintos/tests/Make.tests
@@ -9,6 +9,8 @@ EXTRA_GRADES = $(foreach subdir,$(TEST_SUBDIRS),$($(subdir)_EXTRA_GRADES))
 OUTPUTS = $(addsuffix .output,$(TESTS) $(EXTRA_GRADES))
 ERRORS = $(addsuffix .errors,$(TESTS) $(EXTRA_GRADES))
 RESULTS = $(addsuffix .result,$(TESTS) $(EXTRA_GRADES))
+SELECTED_TESTS = $(filter-out $(EXCLUDE_TESTS),$(TESTS) $(EXTRA_GRADES))
+SELECTED_RESULTS = $(addsuffix .result,$(SELECTED_TESTS))
 
 ifdef PROGS
 include ../../Makefile.userprog
@@ -18,8 +20,10 @@ TIMEOUT = 60
 MEMORY = 20
 SWAP_DISK = 4
 
+.PHONY: selected-check selected-results
+
 clean::
-	rm -f $(OUTPUTS) $(ERRORS) $(RESULTS) 
+	rm -f $(OUTPUTS) $(ERRORS) $(RESULTS) selected-results
 
 grade:: results
 	$(SRCDIR)/tests/make-grade $(SRCDIR) $< $(GRADING_FILE) | tee $@
@@ -32,11 +36,31 @@ check:: results
 		echo "All $$COUNT tests passed.";			  \
 	else								  \
 		echo "$$FAILURES of $$COUNT tests failed.";		  \
+			exit 1;							  \
+	fi
+
+selected-check:: selected-results
+	@cat $<
+	@COUNT="`egrep '^(pass|FAIL) ' $< | wc -l | sed 's/[ 	]//g;'`"; \
+	FAILURES="`egrep '^FAIL ' $< | wc -l | sed 's/[ 	]//g;'`"; \
+	if [ $$FAILURES = 0 ]; then					  \
+		echo "All $$COUNT selected tests passed.";		  \
+	else								  \
+		echo "$$FAILURES of $$COUNT selected tests failed.";	  \
 		exit 1;							  \
 	fi
 
 results: $(RESULTS)
 	@for d in $(TESTS) $(EXTRA_GRADES); do			\
+		if echo PASS | cmp -s $$d.result -; then	\
+			echo "pass $$d";			\
+		else						\
+			echo "FAIL $$d";			\
+		fi;						\
+	done > $@
+
+selected-results: $(SELECTED_RESULTS)
+	@for d in $(SELECTED_TESTS); do				\
 		if echo PASS | cmp -s $$d.result -; then	\
 			echo "pass $$d";			\
 		else						\

--- a/pintos/tests/Make.tests
+++ b/pintos/tests/Make.tests
@@ -9,6 +9,11 @@ EXTRA_GRADES = $(foreach subdir,$(TEST_SUBDIRS),$($(subdir)_EXTRA_GRADES))
 OUTPUTS = $(addsuffix .output,$(TESTS) $(EXTRA_GRADES))
 ERRORS = $(addsuffix .errors,$(TESTS) $(EXTRA_GRADES))
 RESULTS = $(addsuffix .result,$(TESTS) $(EXTRA_GRADES))
+SELECTED_TESTS = $(filter-out $(EXCLUDE_TESTS),$(TESTS) $(EXTRA_GRADES))
+ifdef INCLUDE_TESTS
+SELECTED_TESTS = $(INCLUDE_TESTS)
+endif
+SELECTED_RESULTS = $(addsuffix .result,$(SELECTED_TESTS))
 
 ifdef PROGS
 include ../../Makefile.userprog

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1260,6 +1260,12 @@ setup_stack (struct intr_frame *if_)
 	 * TODO: 페이지가 stack임을 표시해야 합니다. */
 	/* TODO: 여기에 코드를 작성하세요 */
 
+	vm_alloc_page (VM_ANON | VM_MARKER_0, stack_bottom, true);
+	vm_claim_page (stack_bottom);
+	
+	struct page *page = spt_find_page (&thread_current ()->spt, stack_bottom);
+	anon_initializer (page, VM_ANON | VM_MARKER_0, page->frame->kva); // TODO. 이거 넣는게 맞나??
+	if_->rsp = USER_STACK;
 	return success;
 }
 #endif /* 가상 메모리(VM) */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1185,6 +1185,8 @@ lazy_load_segment (struct page *page, void *aux)
 		return false;
 	}
 	memset (kpage + read_bytes, 0, zero_bytes);
+
+	return true;
 }
 
 /* FILE의 오프셋 OFS에서 시작해 주소 UPAGE에 위치한 세그먼트를 로드합니다.  전체적으로 READ_BYTES +

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1205,7 +1205,18 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		/* Project 3 구현 시 struct lazy_load_segment_aux를 page마다 만들어
 		 * file, offset, read/zero byte 수를 넘긴다. 이렇게 하면 lazy load와
 		 * mmap 모두 file position 공유 없이 file_read_at() 기반으로 이어갈 수 있다. */
-		void *aux = NULL;
+		struct lazy_load_segment_aux *aux = malloc (sizeof (struct lazy_load_segment_aux));
+
+		if (aux == NULL) {
+			return false;
+		}
+		
+		aux->file = file;
+		aux->ofs = ofs;
+		aux->read_bytes = page_read_bytes;
+		aux->zero_bytes = page_zero_bytes;
+		
+
 		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
 											writable, lazy_load_segment, aux))
 			return false;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1181,7 +1181,6 @@ lazy_load_segment (struct page *page, void *aux)
 	void* kpage = page->frame->kva;
 	
 	if (!read_file_exact_at (file, kpage, read_bytes, ofs)) {
-		palloc_free_page (kpage);
 		return false;
 	}
 	memset (kpage + read_bytes, 0, zero_bytes);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -522,15 +522,16 @@ process_exec (void *f_name)
 		 parsing 이후이기 때문에, 첫 인자로 argv_tokens[0]을 넘겨주어야 한다.
 	*/
 	success = load (argv_tokens[0], &_if, argc, argv_tokens); // argv_tokens[0]에 해당하는 실행 파일을 찾아 메모리에 올리고, argv_tokens에 있는 인자들을 유저 스택에 올려서 성공하면 1, 실패하면 0 반환
-
 	/* 로드에 실패하면 종료합니다. 
 		 file_name은 f_name의 포인터이므로, f_name을 free 하는 것과 같음. 
 		 f_name은 process_create_initd()에서 할당 받은 페이지
 	*/
 	palloc_free_page (argv_tokens);
 	palloc_free_page (file_name);
-	if (!success)
+	if (!success) {
 		return -1;
+	}
+		
 
 	/* 전환된 프로세스를 시작합니다. */
 	do_iret (&_if);
@@ -908,7 +909,10 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 				 	 */
 					if (!load_segment (file, file_page, (void *) mem_page,
 								read_bytes, zero_bytes, writable))
+					{	
 						goto done;
+					}
+						
 				} else {
 					goto done;
 				}
@@ -1266,6 +1270,7 @@ setup_stack (struct intr_frame *if_)
 	struct page *page = spt_find_page (&thread_current ()->spt, stack_bottom);
 	anon_initializer (page, VM_ANON | VM_MARKER_0, page->frame->kva); // TODO. 이거 넣는게 맞나??
 	if_->rsp = USER_STACK;
+	success = true;
 	return success;
 }
 #endif /* 가상 메모리(VM) */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1,4 +1,4 @@
-#define VM
+// #define VM
 
 #include "userprog/process.h"
 #include <debug.h>

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1169,9 +1169,22 @@ struct lazy_load_segment_aux {
 static bool
 lazy_load_segment (struct page *page, void *aux)
 {
-	/* TODO: 파일에서 세그먼트를 로드하세요 */
-	/* TODO: 주소 VA에서 첫 페이지 폴트가 발생했을 때 호출됩니다. */
-	/* TODO: 이 함수를 호출할 때 VA를 사용할 수 있습니다. */
+	if (aux == NULL) {
+		return false;
+	}
+	struct file *file = ((struct lazy_load_segment_aux *) aux)->file;
+	off_t ofs = ((struct lazy_load_segment_aux *) aux)->ofs;
+	uint32_t read_bytes = ((struct lazy_load_segment_aux *) aux)->read_bytes;
+	uint32_t zero_bytes = ((struct lazy_load_segment_aux *) aux)->zero_bytes;
+	free (aux);
+
+	void* kpage = page->frame->kva;
+	
+	if (!read_file_exact_at (file, kpage, read_bytes, ofs)) {
+		palloc_free_page (kpage);
+		return false;
+	}
+	memset (kpage + read_bytes, 0, zero_bytes);
 }
 
 /* FILE의 오프셋 OFS에서 시작해 주소 UPAGE에 위치한 세그먼트를 로드합니다.  전체적으로 READ_BYTES +

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1233,8 +1233,12 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		
 
 		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
-											writable, lazy_load_segment, aux))
+											writable, lazy_load_segment, aux)) 
+		{
+			free (aux);
 			return false;
+		}
+			
 
 		/* 다음으로 진행합니다. */
 		read_bytes -= page_read_bytes;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1,5 +1,3 @@
-#define VM
-
 #include "userprog/process.h"
 #include <debug.h>
 #include <inttypes.h>

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1181,6 +1181,7 @@ lazy_load_segment (struct page *page, void *aux)
 	void* kpage = page->frame->kva;
 	
 	if (!read_file_exact_at (file, kpage, read_bytes, ofs)) {
+		palloc_free_page (kpage);
 		return false;
 	}
 	memset (kpage + read_bytes, 0, zero_bytes);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1158,6 +1158,14 @@ install_page (void *upage, void *kpage, bool writable)
 /* 여기부터의 코드는 project 3 이후에 사용됩니다.
  * 함수를 project 2에만 구현하고 싶다면 위쪽 블록에 구현하세요. */
 
+/* page fault가 일어났을때 frame을 어떻게 채울지 */
+struct lazy_load_segment_aux {
+	struct file *file; // 어느 실행 파일을 읽을지
+	off_t ofs; // 실행 파일의 어느 위치부터(숫자값) 읽을지
+	uint32_t read_bytes; // 이 page file에서 몇바이트 읽을지
+	uint32_t zero_bytes; // 채워지지 않은 만큼 0으로 채워놓음
+};
+
 static bool
 lazy_load_segment (struct page *page, void *aux)
 {

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -211,20 +211,20 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 		uint64_t *pte = pml4e_walk (thread_current ()->pml4,
 				(const uint64_t) i, true);
 		
-		if (pte == NULL || (*pte & PTE_U) == 0) {
-			printf ("[debug] validate_user_buffer: invalid user PTE "
-					"addr=%p pte=%p pte_val=%llx access=%d\n",
-					(const void *) i, (void *) pte,
-					pte != NULL ? (unsigned long long) *pte : 0, access);
+		if (pte == NULL  || (*pte & PTE_U) == 1) {
+			// printf ("[debug] validate_user_buffer: invalid user PTE "
+			// 		"addr=%p pte=%p pte_val=%llx access=%d\n",
+			// 		(const void *) i, (void *) pte,
+			// 		pte != NULL ? (unsigned long long) *pte : 0, access);
 			thread_exit ();
 		}
 
 		// PTE_P == 0 분기 분리
 		if ((*pte & PTE_P) == 0) {
-			printf ("[debug] validate_user_buffer: non-present page "
-					"addr=%p pte=%p pte_val=%llx access=%d\n",
-					(const void *) i, (void *) pte,
-					(unsigned long long) *pte, access);
+			// printf ("[debug] validate_user_buffer: non-present page "
+			// 		"addr=%p pte=%p pte_val=%llx access=%d\n",
+			// 		(const void *) i, (void *) pte,
+			// 		(unsigned long long) *pte, access);
 			// 스레드 구조체 내부에 다 있다...
 			if (spt_find_page (&thread_current ()->spt, i) == NULL) {
 				thread_exit ();

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -78,6 +78,8 @@ syscall_handler (struct intr_frame *f)
 {
 	// TODO: 구현을 여기에 작성하라.
 	/* rax에 syscall 번호가 들어 있다. */
+	void * buffer;
+	unsigned size;
 	switch (f->R.rax) {
 
 		/* 시스템 종료 */
@@ -114,12 +116,18 @@ syscall_handler (struct intr_frame *f)
 			break;
 
 		case SYS_READ:
+			buffer = (void *) f->R.rsi;
+			size = (unsigned) f->R.rdx;
+			validate_user_read (buffer, size);
 			f->R.rax = sys_read ((int) f->R.rdi, 
 								 (void *) f->R.rsi,
 								 (unsigned) f->R.rdx);
 			break;
 
 		case SYS_WRITE:
+			buffer = (void *) f->R.rsi;
+			size = (unsigned) f->R.rdx;
+			validate_user_write (buffer, size);
 			f->R.rax = sys_write ((int) f->R.rdi, 
 								 (const void *) f->R.rsi,
 								 (unsigned) f->R.rdx);
@@ -211,11 +219,11 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 		uint64_t *pte = pml4e_walk (thread_current ()->pml4,
 				(const uint64_t) i, true);
 		
-		if (pte == NULL  || (*pte & PTE_U) == 1) {
-			// printf ("[debug] validate_user_buffer: invalid user PTE "
-			// 		"addr=%p pte=%p pte_val=%llx access=%d\n",
-			// 		(const void *) i, (void *) pte,
-			// 		pte != NULL ? (unsigned long long) *pte : 0, access);
+		if (pte == NULL  || (*pte & PTE_U) == 0) {
+			printf ("[debug] validate_user_buffer: invalid user PTE "
+					"addr=%p pte=%p pte_val=%llx access=%d\n",
+					(const void *) i, (void *) pte,
+					pte != NULL ? (unsigned long long) *pte : 0, access);
 			thread_exit ();
 		}
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -117,18 +117,12 @@ syscall_handler (struct intr_frame *f)
 			break;
 
 		case SYS_READ:
-			buffer = (void *) f->R.rsi;
-			size = (unsigned) f->R.rdx;
-			validate_user_read (buffer, size);
 			f->R.rax = sys_read ((int) f->R.rdi, 
 								 (void *) f->R.rsi,
 								 (unsigned) f->R.rdx);
 			break;
 
 		case SYS_WRITE:
-			buffer = (void *) f->R.rsi;
-			size = (unsigned) f->R.rdx;
-			validate_user_write (buffer, size);
 			f->R.rax = sys_write ((int) f->R.rdi, 
 								 (const void *) f->R.rsi,
 								 (unsigned) f->R.rdx);

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -220,7 +220,7 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 		uint64_t *pte = pml4e_walk (thread_current ()->pml4,
 				(const uint64_t) i, true);
 		
-		if (pte == NULL  || (*pte & PTE_U) == 0) {
+		if (pte == NULL || (((*pte & PTE_P) == 1) && (*pte & PTE_U) == 0)) {
 			printf ("[debug] validate_user_buffer: invalid user PTE "
 					"addr=%p pte=%p pte_val=%llx access=%d\n",
 					(const void *) i, (void *) pte,

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -224,7 +224,7 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 			printf ("[debug] validate_user_buffer: invalid user PTE "
 					"addr=%p pte=%p pte_val=%llx access=%d\n",
 					(const void *) i, (void *) pte,
-					pte != NULL ? (unsigned long long) *pte : 0, access);
+					pte != NULL ? (unsigned long long) *pte : 123, access);
 			thread_exit ();
 		}
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -18,6 +18,7 @@
 #include "userprog/fd.h"
 #include "userprog/process.h"
 #include "intrinsic.h"
+#include "vm/vm.h"
 
 
 void syscall_entry (void);

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -198,17 +198,40 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 	const uint8_t *start_page = pg_round_down (bf);
 	const uint8_t *end_page = pg_round_down (end_adr);
 
-	// buffer가 걸쳐진 모든 page를 순회 (페이지 단위로 확인)
-	// buffer의 시작주소 + PGSIZE: buffer의 끝 주소까지 순회
+	/* buffer가 걸쳐진 page를 순회 (페이지 단위로 확인)
+	 * buffer의 시작주소 + PGSIZE: buffer의 끝 주소까지 순회
+	 * i는 buffer가 걸친 각 페이지의 시작 주소를 가리킴 */
 	for (const uint8_t *i = start_page; i <= end_page; i += PGSIZE) {
 		// page 시작주소가 user virtual address 범위 안에 있지 않다면 현재 프로세스 exit(-1)
 		if (!is_user_vaddr (i))
 			thread_exit ();
 
+		/* 현재 프로세스의 페이지 테이블에서 유저 가상주소 i에 해당하는 PTE를 찾는다.
+			create=false이므로, 없으면 새로 만들지 않고 NULL을 반환한다. */
 		uint64_t *pte = pml4e_walk (thread_current ()->pml4,
 				(const uint64_t) i, false);
-		if (pte == NULL || (*pte & PTE_P) == 0 || (*pte & PTE_U) == 0)
+		
+		if (pte == NULL || (*pte & PTE_U) == 0) {
+			printf ("[debug] validate_user_buffer: invalid user PTE "
+					"addr=%p pte=%p pte_val=%llx access=%d\n",
+					(const void *) i, (void *) pte,
+					pte != NULL ? (unsigned long long) *pte : 0, access);
 			thread_exit ();
+		}
+
+		// PTE_P == 0 분기 분리
+		if ((*pte & PTE_P) == 0) {
+			printf ("[debug] validate_user_buffer: non-present page "
+					"addr=%p pte=%p pte_val=%llx access=%d\n",
+					(const void *) i, (void *) pte,
+					(unsigned long long) *pte, access);
+			// 스레드 구조체 내부에 다 있다...
+			if (spt_find_page (&thread_current ()->spt, i) == NULL) {
+				thread_exit ();
+			} else {
+				vm_claim_page(i);
+			}
+		}
 
 		if (access == USER_ACCESS_WRITE && (*pte & PTE_W) == 0)
 			thread_exit ();

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -250,13 +250,13 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 void
 validate_user_read (const void *buffer, size_t size)
 {
-	validate_user_buffer (buffer, size, USER_ACCESS_WRITE);
+	validate_user_buffer (buffer, size, USER_ACCESS_READ);
 }
 
 void
 validate_user_write (const void *buffer, size_t size)
 {
-	validate_user_buffer (buffer, size, USER_ACCESS_READ);
+	validate_user_buffer (buffer, size, USER_ACCESS_WRITE);
 }
 
 void

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -209,7 +209,7 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 		/* 현재 프로세스의 페이지 테이블에서 유저 가상주소 i에 해당하는 PTE를 찾는다.
 			create=false이므로, 없으면 새로 만들지 않고 NULL을 반환한다. */
 		uint64_t *pte = pml4e_walk (thread_current ()->pml4,
-				(const uint64_t) i, false);
+				(const uint64_t) i, true);
 		
 		if (pte == NULL || (*pte & PTE_U) == 0) {
 			printf ("[debug] validate_user_buffer: invalid user PTE "

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -159,6 +159,7 @@ syscall_handler (struct intr_frame *f)
 			if (process_exec (kernel_page) == -1) {
 				thread_exit ();
 			}
+			break;
 			
 		}
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -250,13 +250,13 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 void
 validate_user_read (const void *buffer, size_t size)
 {
-	validate_user_buffer (buffer, size, USER_ACCESS_READ);
+	validate_user_buffer (buffer, size, USER_ACCESS_WRITE);
 }
 
 void
 validate_user_write (const void *buffer, size_t size)
 {
-	validate_user_buffer (buffer, size, USER_ACCESS_WRITE);
+	validate_user_buffer (buffer, size, USER_ACCESS_READ);
 }
 
 void

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -237,8 +237,13 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 			}
 		}
 
-		if (access == USER_ACCESS_WRITE && (*pte & PTE_W) == 0)
+		if (access == USER_ACCESS_WRITE && (*pte & PTE_W) == 0) {
+			printf ("[debug] validate_user_buffer: write access denied "
+					"buffer=%p size=%zu page=%p access=%d pte=%p pte_val=%llx\n",
+					buffer, size, (const void *) i, access, (void *) pte,
+					(unsigned long long) *pte);
 			thread_exit ();
+		}
 	}
 }
 

--- a/pintos/vm/Makefile
+++ b/pintos/vm/Makefile
@@ -1,1 +1,38 @@
 include ../Makefile.kernel
+
+P2_TEST_SUBDIRS = tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads
+P2_USER_TEST_SUBDIRS = tests/userprog tests/threads
+P2_FORK_DEPENDENT_TESTS = tests/userprog/fork-%
+P2_FORK_DEPENDENT_TESTS += tests/userprog/wait-simple
+P2_FORK_DEPENDENT_TESTS += tests/userprog/wait-twice
+P2_FORK_DEPENDENT_TESTS += tests/userprog/wait-killed
+P2_FORK_DEPENDENT_TESTS += tests/userprog/exec-boundary
+P2_FORK_DEPENDENT_TESTS += tests/userprog/exec-read
+P2_FORK_DEPENDENT_TESTS += tests/userprog/multi-recurse
+P2_FORK_DEPENDENT_TESTS += tests/userprog/multi-child-fd
+P2_FORK_DEPENDENT_TESTS += tests/userprog/rox-child
+P2_FORK_DEPENDENT_TESTS += tests/userprog/rox-multichild
+P2_FORK_DEPENDENT_TESTS += tests/userprog/no-vm/multi-oom
+P2_EXEC_BASIC_TESTS = tests/userprog/exec-once tests/userprog/exec-arg
+P2_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_TEST_SUBDIRS) lib/user))
+P2_USER_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_USER_TEST_SUBDIRS) lib/user))
+
+.PHONY: p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results
+
+p2-nofork-check: $(P2_DIRS) build/Makefile
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P2_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
+
+p2-nofork-results: $(P2_DIRS) build/Makefile
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P2_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
+
+p2-user-nofork-check: $(P2_USER_DIRS) build/Makefile
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P2_USER_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
+
+p2-user-nofork-results: $(P2_USER_DIRS) build/Makefile
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P2_USER_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
+
+p2-exec-basic-check: $(P2_USER_DIRS) build/Makefile
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="tests/userprog" INCLUDE_TESTS="$(P2_EXEC_BASIC_TESTS)"
+
+p2-exec-basic-results: $(P2_USER_DIRS) build/Makefile
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="tests/userprog" INCLUDE_TESTS="$(P2_EXEC_BASIC_TESTS)"

--- a/pintos/vm/Makefile
+++ b/pintos/vm/Makefile
@@ -13,10 +13,25 @@ P2_FORK_DEPENDENT_TESTS += tests/userprog/multi-child-fd
 P2_FORK_DEPENDENT_TESTS += tests/userprog/rox-child
 P2_FORK_DEPENDENT_TESTS += tests/userprog/rox-multichild
 P2_FORK_DEPENDENT_TESTS += tests/userprog/no-vm/multi-oom
+P2_POINTER_TESTS = tests/userprog/create-bad-ptr
+P2_POINTER_TESTS += tests/userprog/create-bound
+P2_POINTER_TESTS += tests/userprog/open-bad-ptr
+P2_POINTER_TESTS += tests/userprog/open-boundary
+P2_POINTER_TESTS += tests/userprog/read-bad-ptr
+P2_POINTER_TESTS += tests/userprog/read-boundary
+P2_POINTER_TESTS += tests/userprog/write-bad-ptr
+P2_POINTER_TESTS += tests/userprog/write-boundary
+P2_POINTER_TESTS += tests/userprog/exec-bad-ptr
+P2_POINTER_TESTS += tests/userprog/bad-read
+P2_POINTER_TESTS += tests/userprog/bad-write
+P2_POINTER_TESTS += tests/userprog/bad-read2
+P2_POINTER_TESTS += tests/userprog/bad-write2
+P2_POINTER_TESTS += tests/userprog/bad-jump
+P2_POINTER_TESTS += tests/userprog/bad-jump2
 P2_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_TEST_SUBDIRS) lib/user))
 P2_USER_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_USER_TEST_SUBDIRS) lib/user))
 
-.PHONY: p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results
+.PHONY: p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-pointer-check p2-pointer-results
 
 p2-nofork-check: $(P2_DIRS) build/Makefile
 	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P2_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
@@ -29,3 +44,9 @@ p2-user-nofork-check: $(P2_USER_DIRS) build/Makefile
 
 p2-user-nofork-results: $(P2_USER_DIRS) build/Makefile
 	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P2_USER_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
+
+p2-pointer-check: $(P2_USER_DIRS) build/Makefile
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P2_USER_TEST_SUBDIRS)" INCLUDE_TESTS="$(P2_POINTER_TESTS)"
+
+p2-pointer-results: $(P2_USER_DIRS) build/Makefile
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P2_USER_TEST_SUBDIRS)" INCLUDE_TESTS="$(P2_POINTER_TESTS)"

--- a/pintos/vm/Makefile
+++ b/pintos/vm/Makefile
@@ -1,1 +1,31 @@
 include ../Makefile.kernel
+
+P2_TEST_SUBDIRS = tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads
+P2_USER_TEST_SUBDIRS = tests/userprog tests/threads
+P2_FORK_DEPENDENT_TESTS = tests/userprog/fork-%
+P2_FORK_DEPENDENT_TESTS += tests/userprog/wait-simple
+P2_FORK_DEPENDENT_TESTS += tests/userprog/wait-twice
+P2_FORK_DEPENDENT_TESTS += tests/userprog/wait-killed
+P2_FORK_DEPENDENT_TESTS += tests/userprog/exec-boundary
+P2_FORK_DEPENDENT_TESTS += tests/userprog/exec-read
+P2_FORK_DEPENDENT_TESTS += tests/userprog/multi-recurse
+P2_FORK_DEPENDENT_TESTS += tests/userprog/multi-child-fd
+P2_FORK_DEPENDENT_TESTS += tests/userprog/rox-child
+P2_FORK_DEPENDENT_TESTS += tests/userprog/rox-multichild
+P2_FORK_DEPENDENT_TESTS += tests/userprog/no-vm/multi-oom
+P2_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_TEST_SUBDIRS) lib/user))
+P2_USER_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_USER_TEST_SUBDIRS) lib/user))
+
+.PHONY: p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results
+
+p2-nofork-check: $(P2_DIRS) build/Makefile
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P2_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
+
+p2-nofork-results: $(P2_DIRS) build/Makefile
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P2_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
+
+p2-user-nofork-check: $(P2_USER_DIRS) build/Makefile
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P2_USER_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"
+
+p2-user-nofork-results: $(P2_USER_DIRS) build/Makefile
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P2_USER_TEST_SUBDIRS)" EXCLUDE_TESTS="$(P2_FORK_DEPENDENT_TESTS)"

--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -49,9 +49,15 @@ uninit_initialize (struct page *page, void *kva) {
 	vm_initializer *init = uninit->init;
 	void *aux = uninit->aux;
 
-	/* TODO: 이 함수를 수정해야 할 수도 있다. */
-	return uninit->page_initializer (page, uninit->type, kva) &&
-		(init ? init (page, aux) : true);
+	if (
+		!uninit->page_initializer (page, uninit->type, kva)
+		&& (init ? init (page, aux) : false)
+	) {
+		// TODO. when fail, free allocated resources...
+		return false;
+	}
+	
+	return true;
 }
 
 /* uninit_page가 보유한 자원을 해제한다. 대부분의 페이지는 다른 page objects로 변환되지만, process exit 시

--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -49,15 +49,9 @@ uninit_initialize (struct page *page, void *kva) {
 	vm_initializer *init = uninit->init;
 	void *aux = uninit->aux;
 
-	if (
-		!uninit->page_initializer (page, uninit->type, kva)
-		&& (init ? init (page, aux) : false)
-	) {
-		// TODO. when fail, free allocated resources...
-		return false;
-	}
-	
-	return true;
+	/* TODO: 이 함수를 수정해야 할 수도 있다. */
+	return uninit->page_initializer (page, uninit->type, kva) &&
+		(init ? init (page, aux) : true);
 }
 
 /* uninit_page가 보유한 자원을 해제한다. 대부분의 페이지는 다른 page objects로 변환되지만, process exit 시

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -8,8 +8,9 @@
 static uint64_t
 hash_func (const struct hash_elem *e, void* aux) {
 	struct page* page = hash_entry (e, struct page, hash_elem);
+	void *va = pg_round_down(page->va);
 
-	return hash_bytes (pg_round_down(page->va), sizeof page->va);
+	return hash_bytes (&va, sizeof va);
 }
 
 /* 두 page의 key인 va 값을 비교한다. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -84,7 +84,8 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	return page;
 }
 
-/* 검증 후 PAGE를 spt에 삽입한다. */
+/* PAGE를 spt에 삽입한다. 같은 va가 이미 있으면 false를 반환한다. */
+
 bool
 spt_insert_page (struct supplemental_page_table *spt,
 		struct page *page) {

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -87,7 +87,7 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 			goto err;
 		}
 		uninit_new (page, upage, init, type, aux, initializer);
-    p->writable = writable;
+		page->writable = writable;
 		
 		if (!spt_insert_page (spt, page)) {
 			free(page);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -97,9 +97,11 @@ struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	struct page *page = malloc (sizeof (struct page));
 	page->va = va;
-	/* TODO: 이 함수를 채워라. */
+
 	struct hash_elem *he = hash_find (&spt->table, &page->hash_elem);
 	free (page);
+	
+	if (he == NULL) return NULL;
 	page = hash_entry (he, struct page, hash_elem);
 
 	return page;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -85,8 +85,10 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		uninit_new (page, upage, init, type, aux, initializer);
 		
 		if (!spt_insert_page (spt, page)) {
+			free(page);
 			goto err;
 		}
+		return true;
 	}
 err:
 	return false;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -66,7 +66,10 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		}
 		struct page *page = malloc (sizeof (struct page));
 		uninit_new (page, upage, init, type, aux, initializer);
-		/* TODO: 페이지를 spt에 삽입한다. */
+		
+		if (!spt_insert_page (spt, page)) {
+			goto err;
+		}
 	}
 err:
 	return false;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -3,6 +3,7 @@
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+#include "lib/kernel/hash.c"
 
 /* 각 subsystem의 초기화 코드를 호출하여 virtual memory subsystem을 초기화한다. */
 void
@@ -183,7 +184,9 @@ vm_do_claim_page (struct page *page) {
 
 /* 새 supplemental page table을 초기화한다. */
 void
-supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
+supplemental_page_table_init (struct supplemental_page_table *spt) {
+	struct hash *hash = &spt->table;
+	hash_init (hash, hash_func, less_func, NULL);
 }
 
 /* supplemental page table을 src에서 dst로 복사한다. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -65,6 +65,8 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 
 	struct supplemental_page_table *spt = &thread_current ()->spt;
 
+
+
 	/* upage가 이미 점유되어 있는지 확인한다. */
 	if (spt_find_page (spt, upage) == NULL) {
 		/* TODO: 페이지를 생성하고, VM type에 따라 initializer를 가져온 다음,
@@ -91,12 +93,15 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		page->writable = writable;
 		
 		if (!spt_insert_page (spt, page)) {
+			printf ("페이지를 SPT에 넣는데 실패했어요....===\n");
+
 			free(page);
 			goto err;
 		}
 		return true;
 	}
 err:
+printf ("아마 spt가 제대로 kill 되지 않은 문제일 수 있어요. ...===\n");
 	return false;
 }
 
@@ -251,9 +256,21 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 		struct supplemental_page_table *src UNUSED) {
 }
 
+void
+vm_hash_destroy_func (struct hash_elem *e, void *aux UNUSED) {
+	struct page * page = hash_entry (e, struct page, hash_elem);
+
+	free (page->frame);
+	free (page);
+}
+
 /* supplemental page table이 보유한 resource를 해제한다. */
 void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	/* TODO: thread가 보유한 모든 supplemental_page_table을 destroy하고
 	 * TODO: 수정된 모든 내용을 storage에 writeback한다. */
+	// TODO. 지금은 그냥 아예 데이터를 삭제해버려요. 하지만 위 TODO가 필요할 수 있어요.
+
+	// TODO. destroy 함수가 필요해요. hash_elem을 받아서 page 자체를 할당 해제하는 함수가 필요해요.
+	hash_clear (spt, vm_hash_destroy_func);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -192,6 +192,7 @@ vm_do_claim_page (struct page *page) {
 	if (pml4_get_page (current->pml4, page->va) == NULL)
 		pml4_set_page (current->pml4, page->va, frame->kva, page->writable);
 	return swap_in (page, frame->kva);
+	// TODO. 시도 도중 실패했다면, 자원 해제하기
 }
 
 /* 새 supplemental page table을 초기화한다. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -124,6 +124,10 @@ vm_get_frame (void) {
 	struct frame *frame = malloc (sizeof (struct frame));
 	ASSERT (frame != NULL);
 	frame->kva = palloc_get_page (PAL_USER);
+	// TODO. 실패하면 쫒아낼 victim을 골라서 걔를 쫒아낸 뒤, 그 공간을 반환하는 로직을 작성해야 합니다.
+	if (frame->kva == NULL) {
+		return NULL;
+	}
 	frame->page = NULL;
 	ASSERT (frame->page == NULL);
 	return frame;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -159,7 +159,7 @@ static struct frame *
 vm_get_frame (void) {
 	struct frame *frame = malloc (sizeof (struct frame));
 	ASSERT (frame != NULL);
-	frame->kva = palloc_get_page (PAL_USER);
+	frame->kva = palloc_get_page (PAL_USER | PAL_ZERO);
 	// TODO. 실패하면 쫒아낼 victim을 골라서 걔를 쫒아낸 뒤, 그 공간을 반환하는 로직을 작성해야 합니다.
 	ASSERT (frame->kva != NULL);
 	frame->page = NULL;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -63,8 +63,8 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		default:
 			break;
 		}
-		struct page *p = malloc(sizeof(struct page));
-		uninit_new (p, upage, init, type, aux, initializer);
+		struct page *page = malloc (sizeof (struct page));
+		uninit_new (page, upage, init, type, aux, initializer);
 		/* TODO: 페이지를 spt에 삽입한다. */
 	}
 err:

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -150,8 +150,7 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
 	struct page *page = NULL;
 	/* TODO: fault를 검증한다. */
-	/* TODO: 여기에 코드를 작성하세요. */
-
+	page = spt_find_page (spt, addr);
 	return vm_do_claim_page (page);
 }
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -65,6 +65,7 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		}
 		struct page *p = malloc(sizeof(struct page));
 		uninit_new (p, upage, init, type, aux, initializer);
+		p->writable = writable;
 		/* TODO: 페이지를 spt에 삽입한다. */
 	}
 err:
@@ -184,7 +185,9 @@ vm_do_claim_page (struct page *page) {
 	page->frame = frame;
 
 	/* TODO: page table entry를 삽입하여 page의 VA를 frame의 PA에 매핑한다. */
-
+	struct thread* current;
+	if (pml4_get_page (current->pml4, page->va) == NULL)
+		pml4_set_page (current->pml4, page->va, frame->kva, page->writable);
 	return swap_in (page, frame->kva);
 }
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -83,6 +83,9 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 			break;
 		}
 		struct page *page = malloc (sizeof (struct page));
+		if (page == NULL) {
+			goto err;
+		}
 		uninit_new (page, upage, init, type, aux, initializer);
     p->writable = writable;
 		

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -186,8 +186,15 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
 	struct supplemental_page_table *spt = &thread_current ()->spt;
 	struct page *page = NULL;
+	if (addr == NULL) {
+		return false;
+	}
 	/* TODO: fault를 검증한다. */
 	page = spt_find_page (spt, addr);
+	if (page == NULL) {
+		// printf ("vm_try_handle_fault에서 찾은 spt entry가 null 이에요.\n");
+		return false;
+	}
 	return vm_do_claim_page (page);
 }
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -83,10 +83,13 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 
 /* 검증 후 PAGE를 spt에 삽입한다. */
 bool
-spt_insert_page (struct supplemental_page_table *spt UNUSED,
-		struct page *page UNUSED) {
+spt_insert_page (struct supplemental_page_table *spt,
+		struct page *page) {
 	int succ = false;
-	/* TODO: 이 함수를 채워라. */
+	
+	if (hash_insert (spt, &page->hash_elem) == NULL) {
+		succ = true;
+	}
 
 	return succ;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -78,8 +78,12 @@ err:
 /* spt에서 VA를 찾아 page를 반환한다. 오류 시 NULL을 반환한다. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-	struct page *page = NULL;
+	struct page *page = malloc (sizeof (struct page));
+	page->va = va;
 	/* TODO: 이 함수를 채워라. */
+	struct hash_elem *he = hash_find (&spt->table, &page->hash_elem);
+	free (page);
+	page = hash_entry (he, struct page, hash_elem);
 
 	return page;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -201,6 +201,8 @@ bool
 vm_claim_page (void *va UNUSED) {
 	struct page *page = NULL;
 	/* TODO: 이 함수를 채우세요. */
+	struct supplemental_page_table *spt = &thread_current ()->spt;
+	page = spt_find_page (spt, va);
 
 	return vm_do_claim_page (page);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -99,14 +99,11 @@ err:
 /* spt에서 VA를 찾아 page를 반환한다. 오류 시 NULL을 반환한다. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-	struct page *page = malloc (sizeof (struct page));
-	page->va = va;
-
-	struct hash_elem *he = hash_find (&spt->table, &page->hash_elem);
-	free (page);
-	
-	if (he == NULL) return NULL;
-	page = hash_entry (he, struct page, hash_elem);
+	struct page dummy;
+	dummy.va = va;
+	/* TODO: 이 함수를 채워라. */
+	struct hash_elem *he = hash_find (&spt->table, &dummy.hash_elem);
+	struct page* page = hash_entry (he, struct page, hash_elem);
 
 	return page;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -120,10 +120,10 @@ vm_evict_frame (void) {
  * 위해 frame을 evict한다. */
 static struct frame *
 vm_get_frame (void) {
-	struct frame *frame = NULL;
-	/* TODO: 이 함수를 채우세요. */
-
+	struct frame *frame = malloc (sizeof (struct frame));
 	ASSERT (frame != NULL);
+	frame->kva = palloc_get_page (PAL_USER);
+	frame->page = NULL;
 	ASSERT (frame->page == NULL);
 	return frame;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -282,5 +282,5 @@ supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	 // TODO. 지금은 그냥 아예 데이터를 삭제해버려요. 하지만 위 TODO가 필요할 수 있어요.
 
 	// TODO. destroy 함수가 필요해요. hash_elem을 받아서 page 자체를 할당 해제하는 함수가 필요해요.
-	hash_clear (spt, vm_hash_destroy_func);
+	hash_clear (&spt->table, vm_hash_destroy_func);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -3,6 +3,7 @@
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+#include "threads/vaddr.h"
 
 /* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
 static uint64_t

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -50,7 +50,8 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		/* TODO: 페이지를 생성하고, VM type에 따라 initializer를 가져온 다음,
 		 * TODO: uninit_new를 호출하여 "uninit" page struct를 생성한다. 그 후
 		 * TODO: uninit_new를 호출한 뒤 필드를 수정해야 한다. */
-
+		struct page *p = malloc(sizeof(struct page));
+		uninit_new(p, upage, init, type, aux, *uninit_initialize);
 		/* TODO: 페이지를 spt에 삽입한다. */
 	}
 err:

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -114,7 +114,8 @@ spt_insert_page (struct supplemental_page_table *spt,
 		struct page *page) {
 	int succ = false;
 	
-	if (hash_insert (spt, &page->hash_elem) == NULL) {
+	/* spt 자체가 아니라 내부 page table을 넘겨야 한다 */
+	if (hash_insert (&spt->table, &page->hash_elem) == NULL) {
 		succ = true;
 	}
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -4,6 +4,7 @@
 #include "vm/vm.h"
 #include "vm/inspect.h"
 #include "threads/vaddr.h"
+#include "threads/mmu.h"
 
 /* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
 static uint64_t

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -125,9 +125,7 @@ vm_get_frame (void) {
 	ASSERT (frame != NULL);
 	frame->kva = palloc_get_page (PAL_USER);
 	// TODO. 실패하면 쫒아낼 victim을 골라서 걔를 쫒아낸 뒤, 그 공간을 반환하는 로직을 작성해야 합니다.
-	if (frame->kva == NULL) {
-		return NULL;
-	}
+	ASSERT (frame->kva != NULL);
 	frame->page = NULL;
 	ASSERT (frame->page == NULL);
 	return frame;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -71,7 +71,7 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		 * TODO: uninit_new를 호출하여 "uninit" page struct를 생성한다. 그 후
 		 * TODO: uninit_new를 호출한 뒤 필드를 수정해야 한다. */
 		bool (*initializer)(struct page *, enum vm_type, void *) = NULL;
-		switch (type)
+		switch (type & 0b11)
 		{
 		case VM_ANON:
 			initializer = anon_initializer;
@@ -201,12 +201,12 @@ vm_dealloc_page (struct page *page) {
 
 /* VA에 할당된 page를 claim한다. */
 bool
-vm_claim_page (void *va UNUSED) {
+vm_claim_page (void *va) {
 	struct page *page = NULL;
 	/* TODO: 이 함수를 채우세요. */
 	struct supplemental_page_table *spt = &thread_current ()->spt;
-	page = spt_find_page (spt, va);
-
+	page = spt_find_page (spt, va);	
+	ASSERT (page != NULL);
 	return vm_do_claim_page (page);
 }
 
@@ -232,7 +232,9 @@ vm_do_claim_page (struct page *page) {
 	ASSERT (current->pml4 != NULL);
 	if (pml4_get_page (current->pml4, page->va) == NULL)
 		pml4_set_page (current->pml4, page->va, frame->kva, page->writable);
-	return swap_in (page, frame->kva);
+	bool result = swap_in (page, frame->kva);
+
+	return result;
 	// TODO. 시도 도중 실패했다면, 자원 해제하기
 }
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -185,7 +185,9 @@ vm_do_claim_page (struct page *page) {
 	page->frame = frame;
 
 	/* TODO: page table entry를 삽입하여 page의 VA를 frame의 PA에 매핑한다. */
-	struct thread* current;
+	struct thread* current = thread_current ();
+	ASSERT (current != NULL);
+	ASSERT (current->pml4 != NULL);
 	if (pml4_get_page (current->pml4, page->va) == NULL)
 		pml4_set_page (current->pml4, page->va, frame->kva, page->writable);
 	return swap_in (page, frame->kva);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -3,7 +3,24 @@
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
-#include "lib/kernel/hash.c"
+
+/* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
+static uint64_t
+hash_func (const struct hash_elem *e, void* aux) {
+	struct page* page = hash_entry (e, struct page, hash_elem);
+
+	return hash_bytes (pg_round_down(page->va), sizeof page->va);
+}
+
+/* 두 page의 key인 va 값을 비교한다. */
+static bool
+less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux) {
+	struct page* pa = hash_entry (a, struct page, hash_elem);
+	struct page* pb = hash_entry (b, struct page, hash_elem);
+
+	return pg_round_down(pa->va) < pg_round_down(pb->va);
+}
+
 
 /* 각 subsystem의 초기화 코드를 호출하여 virtual memory subsystem을 초기화한다. */
 void

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -107,6 +107,9 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	dummy.va = va;
 	/* TODO: 이 함수를 채워라. */
 	struct hash_elem *he = hash_find (&spt->table, &dummy.hash_elem);
+	if (he == NULL) { 
+		return NULL;
+	}
 	struct page* page = hash_entry (he, struct page, hash_elem);
 
 	return page;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -167,7 +167,14 @@ vm_claim_page (void *va UNUSED) {
 	return vm_do_claim_page (page);
 }
 
-/* PAGE를 claim하고 mmu를 설정한다. */
+/* PAGE를 claim하고 mmu를 설정한다. 
+	페이지를 claim한다는 것은 물리 프레임(physical frame)을 할당한다는 뜻입니다. 
+	먼저 vm_get_frame을 호출하여 프레임을 얻습니다. 
+	이 부분은 템플릿에서 이미 처리되어 있습니다. 
+	그런 다음 MMU를 설정해야 합니다. 
+	다시 말해 페이지 테이블(page table)에 가상 주소에서 물리 주소로의 매핑을 
+	추가해야 합니다. 반환값은 이 작업이 성공했는지 여부를 나타내야 합니다.
+*/
 static bool
 vm_do_claim_page (struct page *page) {
 	struct frame *frame = vm_get_frame ();

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -258,9 +258,23 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 		struct supplemental_page_table *src UNUSED) {
 }
 
+void
+vm_hash_destroy_func (struct hash_elem *e, void *aux UNUSED) {
+	struct page * page = hash_entry (e, struct page, hash_elem);
+
+	free (page->frame);
+	free (page);
+}
+
 /* supplemental page table이 보유한 resource를 해제한다. */
 void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 	/* TODO: thread가 보유한 모든 supplemental_page_table을 destroy하고
 	 * TODO: 수정된 모든 내용을 storage에 writeback한다. */
+	
+	
+	 // TODO. 지금은 그냥 아예 데이터를 삭제해버려요. 하지만 위 TODO가 필요할 수 있어요.
+
+	// TODO. destroy 함수가 필요해요. hash_elem을 받아서 page 자체를 할당 해제하는 함수가 필요해요.
+	hash_clear (spt, vm_hash_destroy_func);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -50,8 +50,21 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		/* TODO: 페이지를 생성하고, VM type에 따라 initializer를 가져온 다음,
 		 * TODO: uninit_new를 호출하여 "uninit" page struct를 생성한다. 그 후
 		 * TODO: uninit_new를 호출한 뒤 필드를 수정해야 한다. */
+		bool (*initializer)(struct page *, enum vm_type, void *) = NULL;
+		switch (type)
+		{
+		case VM_ANON:
+			initializer = anon_initializer;
+			break;
+		case VM_FILE:
+			initializer = file_backed_initializer;
+			break;
+		
+		default:
+			break;
+		}
 		struct page *p = malloc(sizeof(struct page));
-		uninit_new(p, upage, init, type, aux, *uninit_initialize);
+		uninit_new (p, upage, init, type, aux, initializer);
 		/* TODO: 페이지를 spt에 삽입한다. */
 	}
 err:

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -181,7 +181,7 @@ vm_handle_wp (struct page *page UNUSED) {
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
+	struct supplemental_page_table *spt = &thread_current ()->spt;
 	struct page *page = NULL;
 	/* TODO: fault를 검증한다. */
 	page = spt_find_page (spt, addr);


### PR DESCRIPTION
pass tests/threads/priority-donate-chain
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
18 of 95 tests failed.
make[1]: *** [../../tests/Make.tests:36: check] Error 1
make[1]: Leaving directory '/workspaces/pintos/pintos/vm/build'
make: *** [../Makefile.kernel:10: check] Error 2


fork 관련 테스트 제외 나머지 테스트들 모두 통과함을 확인했습니다.