### PR TITLE
Issue 323 vm stack growth hg

### DIFF
--- a/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
+++ b/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
@@ -252,11 +252,11 @@ make p2-exec-basic-results
 
 요약은 `pintos/vm/build/selected-results`에 생긴다.
 
-## Project 3 stack growth 테스트 실행
+## Project 3 PT/stack growth 테스트 실행
 
-Project 3의 stack growth 관련 핵심 테스트만 확인하려면 `pintos/vm`에서 개별 `.result` 타깃을 실행한다.
+Project 3의 page table 및 stack growth 관련 PT 테스트를 확인하려면 `pintos/vm`에서 편의 타깃이나 개별 `.result` 타깃을 실행한다.
 
-가장 권장하는 방식은 `pintos/vm/Makefile`에 추가된 편의 타깃을 쓰는 것이다. 이 타깃은 `build/` 준비, 하위 디렉터리 생성, `TEST_SUBDIRS="tests/vm tests/threads"`, `FSDISK=10` 전달을 한 번에 처리한다.
+가장 권장하는 방식은 `pintos/vm/Makefile`에 추가된 편의 타깃을 쓰는 것이다. 이 타깃은 `build/` 준비, 하위 디렉터리 생성, `TEST_SUBDIRS="tests/vm tests/threads"`, `FSDISK=10` 전달을 한 번에 처리한다. 또한 `tests/vm/Make.tests`에서 실행 대상 바이너리를 `PUTFILES`로 자동 등록하므로, 개별 명령에 `PUTFILES=...`를 직접 붙이지 않아도 된다.
 
 테스트 하나만 실행:
 
@@ -279,30 +279,36 @@ cd /workspaces/pintos/pintos/vm
 make p3-stack-one-output P3_STACK_TEST=pt-grow-stack
 ```
 
-핵심 4개를 한 번에 실행:
+PT 8개를 한 번에 실행:
 
 ```bash
 cd /workspaces/pintos/pintos/vm
-make p3-stack-growth-check
+make p3-pt-check
 ```
 
 결과 파일만 갱신하고 요약 파일을 만들려면:
 
 ```bash
-make p3-stack-growth-results
+make p3-pt-results
 cat build/selected-results
 ```
+
+기존 이름인 `p3-stack-growth-check`, `p3-stack-growth-results`도 남아 있지만, 이제는 4개가 아니라 아래 PT 8개 전체를 실행하는 alias다.
 
 이 타깃은 내부적으로 `TEST_SUBDIRS="tests/vm tests/threads"`를 사용한다. `tests/threads`는 실행하려는 테스트 묶음이 아니라 커널 링크에 필요한 `run_test` 정의를 포함시키기 위한 빌드 의존성이다. 빼면 `undefined reference to run_test` 링크 에러가 날 수 있다.
 
 또한 내부 make에 `FSDISK=10`을 명시적으로 넘긴다. 이 값이 빠지면 실행 명령이 `--fs-disk=`처럼 비어 파일 시스템 초기화 단계에서 `hd0:1 (hdb) not present` panic이 날 수 있다.
 
-포함되는 핵심 테스트는 다음 네 개다.
+포함되는 PT 테스트는 다음 여덟 개다.
 
 ```text
 tests/vm/pt-grow-stack
 tests/vm/pt-grow-bad
 tests/vm/pt-big-stk-obj
+tests/vm/pt-bad-addr
+tests/vm/pt-bad-read
+tests/vm/pt-write-code
+tests/vm/pt-write-code2
 tests/vm/pt-grow-stk-sc
 ```
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -134,9 +134,11 @@ struct thread {
 	struct file *fd_table[FD_MAX];     	/* 프로세스별 파일 디스크립터 테이블 */
 	int next_fd;                       	/* 다음 할당 후보 fd */
 // #endif
+	uintptr_t rsp;
 #ifdef VM
 	/* thread가 소유한 전체 virtual memory에 대한 테이블. */
 	struct supplemental_page_table spt;
+	
 #endif
 
 	/* thread.c가 소유한다. */

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -114,4 +114,7 @@ void vm_dealloc_page (struct page *page);
 bool vm_claim_page (void *va);
 enum vm_type page_get_type (struct page *page);
 
+bool is_valid_stack_growth_request (bool user, struct intr_frame* f, void* addr, struct page* page);
+
+
 #endif  /* VM_VM_H */

--- a/pintos/tests/vm/Make.tests
+++ b/pintos/tests/vm/Make.tests
@@ -1,5 +1,8 @@
 # -*- makefile -*-
 
+tests/%.output: FSDISK = 10
+tests/%.output: PUTFILES = $(filter-out os.dsk, $^)
+
 tests/vm_TESTS = $(addprefix tests/vm/,pt-grow-stack	\
 pt-grow-bad pt-big-stk-obj pt-bad-addr pt-bad-read pt-write-code	\
 pt-write-code2 pt-grow-stk-sc page-linear page-parallel page-merge-seq	\

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -960,7 +960,7 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 		int len = strlen(argv_tokens[i]) + 1; // 문자열 끝 \0 포함
 		rsp -= len; // 문자열 길이만큼 메모리 낮은 주소로 가서 높은 주소 방향으로 문자열 복사
 		if (rsp < USER_STACK - PGSIZE) {
-			// goto done; // rsp가 계속 작아지다가 USER_STACK - PGSIZE 보다 작아지면, 할당된 스택 page 바깥이라 잘못된 접근
+			goto done; // rsp가 계속 작아지다가 USER_STACK - PGSIZE 보다 작아지면, 할당된 스택 page 바깥이라 잘못된 접근
 		} 
 		memcpy((void *) rsp, argv_tokens[i], len);
 		/* 이후 argv 배열(명령어 문자열 인자들의 주소 배열)을 스택에 저장하기 위해 주소들을 arg_addr에 저장 */
@@ -969,12 +969,12 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 	/* rsp는 원래 uintptr_t 타입이므로, rsp를 8로 나눈 나머지를 원래 rsp에서 빼주면 8의 배수로 내림 정렬이 된다.*/
 	rsp -= (rsp % 8);
 	if (rsp < USER_STACK - PGSIZE) {
-		// goto done;
+		goto done;
 	}
 	/* NULL pointer 크기 만큼 rsp 내려감 */
 	rsp -= 8;
 	if (rsp < USER_STACK - PGSIZE) {
-		// goto done;
+		goto done;
 	}
 	/* argv[argc] = NULL 
 	 * uintptr_t는 주소를 담을 수 있는 정수 타입이다.
@@ -990,7 +990,7 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 	for (int i = argc - 1; i >= 0; i--) {
 		rsp -= 8;
 		if (rsp < USER_STACK - PGSIZE) {
-			// goto done;
+			goto done;
 		}
 		*(char **) rsp = arg_addr[i];
 	}
@@ -1000,7 +1000,7 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 
 	rsp -= 8;
 	if (rsp < USER_STACK - PGSIZE) {
-	// 	goto done;
+		goto done;
 	}
 	/* fake return address */
 	*(uintptr_t *) rsp = 0;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -1,4 +1,3 @@
-
 #include "userprog/process.h"
 #include <debug.h>
 #include <inttypes.h>
@@ -25,6 +24,7 @@
 #include "debug_log.h"
 #ifdef VM
 #include "vm/vm.h"
+#include "debug_log.h"
 #endif
 
 #define MAX_ARGS PGSIZE / sizeof(char *) - 1
@@ -539,6 +539,7 @@ process_exec (void *f_name)
 	palloc_free_page (argv_tokens);
 	palloc_free_page (file_name);
 	if (!success) {
+		DBG ("process_exec:load 실패...\n");
 		return -1;
 	}
 		
@@ -930,14 +931,19 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 		}
 	}
 
+	DBG ("load:load_segemt success...\n");
+
 	/* 유저 주소 공간의 맨 위쪽에 스택용 페이지 하나를 만들어준다.
 	 * 내부적으로
 	 * 1. 커널에서 물리 페이지 하나를 할당한다.
 	 * 2. 그 페이지를 유저 가상 주소 USER_STACK - PGSIZE 위치에 매핑한다.
    * 3. if_->rsp를 USER_STACK으로 설정한다. (스택 포인터는 빈 스택의 초기 rsp 값, 스택의 가장 높은 주소 경계를 가리키게 됨)
 	*/
-	if (!setup_stack (if_))
+	if (!setup_stack (if_)) {
+		DBG ("load:setup_stack fail...\n");
 		goto done;
+	}
+		
 
 	/* ELF 엔트리 주소(실행 파일의 시작 주소)를 if_->rip에 저장 (instruction pointer, 즉 CPU가 다음에 실행할 명령어의 주소에 저장하는 것)
 		 프로그램이 처음 실행될 시작 주소를 CPU 상태에 넣어두는 것, do_iret()으로 유저 모드에 들어갈 때, CPU가 ehdr.e_entry 주소부터 실행하게 됨.
@@ -954,7 +960,7 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 		int len = strlen(argv_tokens[i]) + 1; // 문자열 끝 \0 포함
 		rsp -= len; // 문자열 길이만큼 메모리 낮은 주소로 가서 높은 주소 방향으로 문자열 복사
 		if (rsp < USER_STACK - PGSIZE) {
-			goto done; // rsp가 계속 작아지다가 USER_STACK - PGSIZE 보다 작아지면, 할당된 스택 page 바깥이라 잘못된 접근
+			// goto done; // rsp가 계속 작아지다가 USER_STACK - PGSIZE 보다 작아지면, 할당된 스택 page 바깥이라 잘못된 접근
 		} 
 		memcpy((void *) rsp, argv_tokens[i], len);
 		/* 이후 argv 배열(명령어 문자열 인자들의 주소 배열)을 스택에 저장하기 위해 주소들을 arg_addr에 저장 */
@@ -963,12 +969,12 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 	/* rsp는 원래 uintptr_t 타입이므로, rsp를 8로 나눈 나머지를 원래 rsp에서 빼주면 8의 배수로 내림 정렬이 된다.*/
 	rsp -= (rsp % 8);
 	if (rsp < USER_STACK - PGSIZE) {
-		goto done;
+		// goto done;
 	}
 	/* NULL pointer 크기 만큼 rsp 내려감 */
 	rsp -= 8;
 	if (rsp < USER_STACK - PGSIZE) {
-		goto done;
+		// goto done;
 	}
 	/* argv[argc] = NULL 
 	 * uintptr_t는 주소를 담을 수 있는 정수 타입이다.
@@ -984,7 +990,7 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 	for (int i = argc - 1; i >= 0; i--) {
 		rsp -= 8;
 		if (rsp < USER_STACK - PGSIZE) {
-			goto done;
+			// goto done;
 		}
 		*(char **) rsp = arg_addr[i];
 	}
@@ -994,7 +1000,7 @@ load (const char *file_name, struct intr_frame *if_, int argc, char *argv_tokens
 
 	rsp -= 8;
 	if (rsp < USER_STACK - PGSIZE) {
-		goto done;
+	// 	goto done;
 	}
 	/* fake return address */
 	*(uintptr_t *) rsp = 0;
@@ -1016,6 +1022,10 @@ done:
 		lock_acquire (&filesys_lock);
 		file_close (file);
 		lock_release (&filesys_lock);
+	}
+
+	if (success != true) {
+		DBG ("load:fail.. might need stack growth...\n");
 	}
 	
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -196,8 +196,11 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 	const uint8_t *end_adr = bf + size - 1;
 
 	// 끝 주소 = 시작 주소보다 같거나 커야 한다, 근데 시작 주소보다 작다 (초과분이 잘린거임)
-	if (end_adr < bf)
+	if (end_adr < bf) {
+		DBG ("validate_user_buffer: end_adr < bf\n");
 		thread_exit ();
+	}
+		
 
 	// 순회할 시작페이지, 끝 페이지 정의
 	const uint8_t *start_page = pg_round_down (bf);
@@ -208,8 +211,11 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 	 * i는 buffer가 걸친 각 페이지의 시작 주소를 가리킴 */
 	for (const uint8_t *i = start_page; i <= end_page; i += PGSIZE) {
 		// page 시작주소가 user virtual address 범위 안에 있지 않다면 현재 프로세스 exit(-1)
-		if (!is_user_vaddr (i))
+		if (!is_user_vaddr (i)) {
+			DBG ("validate_user_buffer: !is_user_vaddr\n");
 			thread_exit ();
+		}
+			
 
 		/* 현재 프로세스의 페이지 테이블에서 유저 가상주소 i에 해당하는 PTE를 찾는다.
 			create=false이므로, 없으면 새로 만들지 않고 NULL을 반환한다. */

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -237,10 +237,17 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 			// 		(const void *) i, (void *) pte,
 			// 		(unsigned long long) *pte, access);
 			// 스레드 구조체 내부에 다 있다...
-			if (spt_find_page (&thread_current ()->spt, i) == NULL) {
-				thread_exit ();
+			struct page *page = spt_find_page (&thread_current ()->spt, i);
+			if (
+				(page == NULL) 
+				&& (i >= thread_current ()->rsp - 8) 
+				&& ((USER_STACK - (uintptr_t) pg_round_down (i)) <= (1 << 20))
+			) {
+				vm_alloc_page (VM_ANON, i, true);
+				vm_claim_page (i);
 			} else {
-				vm_claim_page(i);
+				DBG ("validate_user_buffer: no spt entry\n");
+				thread_exit ();
 			}
 		}
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -79,8 +79,7 @@ syscall_handler (struct intr_frame *f)
 {
 	// TODO: 구현을 여기에 작성하라.
 	/* rax에 syscall 번호가 들어 있다. */
-	void * buffer;
-	unsigned size;
+	thread_current ()->rsp = f->rsp;
 	switch (f->R.rax) {
 
 		/* 시스템 종료 */
@@ -176,6 +175,7 @@ syscall_handler (struct intr_frame *f)
 			break;
 		
 	}
+	thread_current ()->rsp = NULL;
 }
 
 /* Project 2는 pml4에 이미 매핑된 page만 user buffer로 인정한다.

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -19,6 +19,7 @@
 #include "userprog/process.h"
 #include "intrinsic.h"
 #include "vm/vm.h"
+#include "debug_log.h"
 
 
 void syscall_entry (void);
@@ -216,7 +217,7 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 				(const uint64_t) i, true);
 		
 		if (pte == NULL || (((*pte & PTE_P) == 1) && (*pte & PTE_U) == 0)) {
-			printf ("[debug] validate_user_buffer: invalid user PTE "
+			DBG ("[debug] validate_user_buffer: invalid user PTE "
 					"addr=%p pte=%p pte_val=%llx access=%d\n",
 					(const void *) i, (void *) pte,
 					pte != NULL ? (unsigned long long) *pte : 123, access);
@@ -238,7 +239,7 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 		}
 
 		if (access == USER_ACCESS_WRITE && (*pte & PTE_W) == 0) {
-			printf ("[debug] validate_user_buffer: write access denied "
+			DBG ("[debug] validate_user_buffer: write access denied "
 					"buffer=%p size=%zu page=%p access=%d pte=%p pte_val=%llx\n",
 					buffer, size, (const void *) i, access, (void *) pte,
 					(unsigned long long) *pte);

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -238,11 +238,7 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 			// 		(unsigned long long) *pte, access);
 			// 스레드 구조체 내부에 다 있다...
 			struct page *page = spt_find_page (&thread_current ()->spt, i);
-			if (
-				(page == NULL) 
-				&& (i >= thread_current ()->rsp - 8) 
-				&& ((USER_STACK - (uintptr_t) pg_round_down (i)) <= (1 << 20))
-			) {
+			if (page == NULL && is_valid_stack_growth_request (false, NULL, i, page)) {
 				vm_alloc_page (VM_ANON, i, true);
 				vm_claim_page (i);
 			} else {

--- a/pintos/vm/Makefile
+++ b/pintos/vm/Makefile
@@ -8,10 +8,14 @@ build/Makefile: | build
 P2_TEST_SUBDIRS = tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads
 P2_USER_TEST_SUBDIRS = tests/userprog tests/threads
 P3_VM_TEST_SUBDIRS = tests/vm tests/threads
-P3_STACK_GROWTH_TESTS = tests/vm/pt-grow-stack
-P3_STACK_GROWTH_TESTS += tests/vm/pt-grow-bad
-P3_STACK_GROWTH_TESTS += tests/vm/pt-big-stk-obj
-P3_STACK_GROWTH_TESTS += tests/vm/pt-grow-stk-sc
+P3_PT_TESTS = tests/vm/pt-grow-stack
+P3_PT_TESTS += tests/vm/pt-grow-bad
+P3_PT_TESTS += tests/vm/pt-big-stk-obj
+P3_PT_TESTS += tests/vm/pt-bad-addr
+P3_PT_TESTS += tests/vm/pt-bad-read
+P3_PT_TESTS += tests/vm/pt-write-code
+P3_PT_TESTS += tests/vm/pt-write-code2
+P3_PT_TESTS += tests/vm/pt-grow-stk-sc
 P3_STACK_GROWTH_REGRESSION_TESTS = tests/vm/page-merge-stk
 P3_STACK_GROWTH_REGRESSION_TESTS += tests/vm/mmap-over-stk
 P3_STACK_TEST ?= pt-grow-stack
@@ -39,7 +43,7 @@ P2_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_TEST_SUBDIRS) lib/use
 P2_USER_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_USER_TEST_SUBDIRS) lib/user))
 P3_VM_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P3_VM_TEST_SUBDIRS) lib/user))
 
-.PHONY: p2-prepare-dirs p3-vm-prepare-dirs p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results p2-pointer-check p2-pointer-results p2-fork-check p2-fork-results p2-fork-one p2-fork-one-result p2-fork-one-output p3-stack-growth-check p3-stack-growth-results p3-stack-growth-regression-results p3-stack-one p3-stack-one-result p3-stack-one-output
+.PHONY: p2-prepare-dirs p3-vm-prepare-dirs p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results p2-pointer-check p2-pointer-results p2-fork-check p2-fork-results p2-fork-one p2-fork-one-result p2-fork-one-output p3-pt-check p3-pt-results p3-stack-growth-check p3-stack-growth-results p3-stack-growth-regression-results p3-stack-one p3-stack-one-result p3-stack-one-output
 
 p2-prepare-dirs: build/Makefile
 	mkdir -p $(P2_DIRS)
@@ -82,14 +86,20 @@ p2-fork-one-output: p2-prepare-dirs
 	cd build && $(MAKE) $(P2_FORK_TEST_PATH).output TEST_SUBDIRS="$(P2_TEST_SUBDIRS)"
 	@cat build/$(P2_FORK_TEST_PATH).output
 
-p3-stack-growth-check: p3-vm-prepare-dirs
-	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_STACK_GROWTH_TESTS)" FSDISK=10
+p3-pt-check: p3-vm-prepare-dirs
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_PT_TESTS)" FSDISK=10
 
-p3-stack-growth-results: p3-vm-prepare-dirs
-	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_STACK_GROWTH_TESTS)" FSDISK=10
+p3-pt-results: p3-vm-prepare-dirs
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_PT_TESTS)" FSDISK=10
+	@cat build/selected-results
+
+p3-stack-growth-check: p3-pt-check
+
+p3-stack-growth-results: p3-pt-results
 
 p3-stack-growth-regression-results: p3-vm-prepare-dirs
-	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_STACK_GROWTH_TESTS) $(P3_STACK_GROWTH_REGRESSION_TESTS)" FSDISK=10
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_PT_TESTS) $(P3_STACK_GROWTH_REGRESSION_TESTS)" FSDISK=10
+	@cat build/selected-results
 
 p3-stack-one: p3-vm-prepare-dirs
 	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_STACK_TEST_PATH)" FSDISK=10

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -287,6 +287,7 @@ vm_claim_page (void *va) {
 */
 static bool
 vm_do_claim_page (struct page *page) {
+	ASSERT (page->frame == NULL);
 	struct frame *frame = vm_get_frame ();
 
 	/* 링크를 설정한다. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -5,6 +5,7 @@
 #include "vm/inspect.h"
 #include "threads/vaddr.h"
 #include "threads/mmu.h"
+#include "debug_log.h"
 
 /* page의 va 값을 key로 삼아 hash table bucket 선택용 해시값을 만든다. */
 static uint64_t
@@ -231,7 +232,7 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 
 	
 	if (page == NULL) {
-		// printf ("vm_try_handle_fault에서 찾은 spt entry가 null 이에요.\n");
+		DBG ("정당하지 않은 page fault 이에요.\n");
 		return false;
 	}
 	return vm_do_claim_page (page);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -189,22 +189,9 @@ static bool
 vm_handle_wp (struct page *page UNUSED) {
 }
 
-/* 성공하면 true를 반환한다. */
 bool
-vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
-		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-	struct supplemental_page_table *spt = &thread_current ()->spt;
-	struct page *page = NULL;
-	
-	void * page_addr = pg_round_down (addr);
-	if (page_addr == NULL) {
-		return false;
-	}
-
-	page = spt_find_page (spt, page_addr);
-
-	/* TODO: fault를 검증한다. 
-		stack growth 를 위한 요청이라면...
+is_valid_stack_growth_request (bool user, struct intr_frame* f, void* addr, struct page* page) {
+	/*	stack growth 를 위한 요청이라면...
 		1. spt 에 없어야 함.
 		2. 스택이라 주장하는 지점이 stack start point 에서 1MB 보다 더 멀리 떨어져서는 안 됨.
 		3. rsp - 8보다 작아서는 안 됨.
@@ -221,21 +208,49 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	}
 
 	if (!is_user_vaddr (addr)) {
+		printf ("유저 가상 메모리가 아님... 죽었다	\n");
 		return false;
 	}
 
 	if (
 		(page == NULL) 
 		&& (addr >= rsp - 8) 
-		&& ((USER_STACK - (uintptr_t) page_addr) <= (1 << 20))
+		&& ((USER_STACK - (uintptr_t) pg_round_down (addr)) <= (1 << 20))
 	) {
-		vm_stack_growth (page_addr);
+		return true;
 	}
-	
-	page = spt_find_page (spt, page_addr);
 
-	
-	if (page == NULL) {
+	DBG ("is_valid_stack_growth_request: false\n");
+	return false;
+}
+
+/* 성공하면 true를 반환한다. */
+bool
+vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
+		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
+	if (!not_present) {
+		DBG ("not present, DIE...	\n");
+		return false;
+	}
+	if (addr == NULL) {
+		DBG ("addr NULL... DIE...	\n");
+		return false;
+	}
+
+	struct supplemental_page_table *spt = &thread_current ()->spt;
+	struct page *page = NULL;
+	void * page_addr = pg_round_down (addr);
+
+	page = spt_find_page (spt, page_addr);
+	if (is_valid_stack_growth_request (user, f, addr, page)) {
+		vm_stack_growth (page_addr);
+	} 
+	/* TODO. else 를 쓰지 않고 이렇게 하는 이유: vm_stack_growth의 반환값이 static void 타입으로 고정되어 있다. 
+	따라서 실제 페이지가 만들어졌는지를 한 번 더 체크해줘야 한다.
+	하지만 이 예외 체크도 완벽히 모든 예외를 체크한다고 할 수는 없다... (page는 생성되었는데 물리 프레임과 매핑이 실패했다면??)
+	*/
+	page = spt_find_page (spt, page_addr);
+	if (page == NULL) {  
 		DBG ("정당하지 않은 page fault 이에요.\n");
 		return false;
 	}

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -178,7 +178,9 @@ vm_get_frame (void) {
 
 /* 스택을 확장한다. */
 static void
-vm_stack_growth (void *addr UNUSED) {
+vm_stack_growth (void *addr) {
+	vm_alloc_page (VM_ANON, addr, true);
+	vm_claim_page (addr);
 }
 
 /* write_protected page에서 발생한 fault를 처리한다. */
@@ -192,11 +194,42 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
 	struct supplemental_page_table *spt = &thread_current ()->spt;
 	struct page *page = NULL;
-	if (addr == NULL) {
+	
+	void * page_addr = pg_round_down (addr);
+	if (page_addr == NULL) {
 		return false;
 	}
-	/* TODO: fault를 검증한다. */
-	page = spt_find_page (spt, addr);
+
+	page = spt_find_page (spt, page_addr);
+
+	/* TODO: fault를 검증한다. 
+		stack growth 를 위한 요청이라면...
+		1. spt 에 없어야 함.
+		2. 스택이라 주장하는 지점이 stack start point 에서 1MB 보다 더 멀리 떨어져서는 안 됨.
+		3. rsp - 8보다 작아서는 안 됨.
+	*/
+	uintptr_t rsp;
+	if (user) {
+		rsp = f->rsp;
+	} else {
+		rsp = thread_current ()->rsp;
+		if (rsp == NULL) {
+			DBG ("kernel page fault 발생, 정당하지 않은 메모리 접근 시도를 차단합니다.\n");
+			return false;
+		}
+	}
+
+	if (
+		(page == NULL) 
+		&& (addr >= rsp - 8) 
+		&& ((USER_STACK - (uintptr_t) page_addr) <= (1 << 20))
+	) {
+		vm_stack_growth (page_addr);
+	}
+	
+	page = spt_find_page (spt, page_addr);
+
+	
 	if (page == NULL) {
 		// printf ("vm_try_handle_fault에서 찾은 spt entry가 null 이에요.\n");
 		return false;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -244,6 +244,7 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	page = spt_find_page (spt, page_addr);
 	if (is_valid_stack_growth_request (user, f, addr, page)) {
 		vm_stack_growth (page_addr);
+		return true;
 	} 
 	/* TODO. else 를 쓰지 않고 이렇게 하는 이유: vm_stack_growth의 반환값이 static void 타입으로 고정되어 있다. 
 	따라서 실제 페이지가 만들어졌는지를 한 번 더 체크해줘야 한다.

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -220,6 +220,10 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		}
 	}
 
+	if (!is_user_vaddr (addr)) {
+		return false;
+	}
+
 	if (
 		(page == NULL) 
 		&& (addr >= rsp - 8) 


### PR DESCRIPTION
## 요약

  - Project 3 VM의 stack growth를 구현했습니다.
  - 사용자 스택 접근으로 판단되는 page fault에서 anonymous stack page를 추가 할당하도록 처리했습니다.
  - stack growth 관련 테스트를 실행하기 쉽도록 VM 테스트 Makefile의 실행 파일 put 누락 문제를 수정했습니다.

  ## 주요 변경 사항

  - `vm_try_handle_fault()`에서 stack growth 대상 fault를 판별하도록 수정
  - `vm_stack_growth()`에서 fault 주소 기준으로 stack page를 할당/claim
  - stack page 최대 크기 제한 및 user address 범위 검증 추가
  - syscall 중 user buffer 접근으로 발생하는 page fault도 처리할 수 있도록 stack pointer 기준 정리
  - 유효한 stack growth 요청인지 판별하는 별도 함수 생성 (bool is_valid_stack_growth_request)
  - `tests/vm` 실행 시 테스트 바이너리가 파일 시스템에 자동으로 올라가도록 Makefile 보완

  ## 테스트

```bash
cd /workspaces/pintos/pintos/vm
make p3-pt-check
```

  ## 참고

  - `pt-grow-stack`은 큰 지역 배열 접근으로 stack growth가 정상 동작하는지 확인합니다.
  - `pt-grow-stk-sc`는 syscall 내부에서 처음 stack page 접근이 발생하는 경우를 확인합니다.
  - `pt-grow-bad`는 stack으로 인정하면 안 되는 접근을 거부하는지 확인합니다.
  -  `validate_user_buffer` 함수에서 `vm_stack_growth` 함수를 호출하지 않고 내부 동작을 그대로 사용합니다. 추후 `vm_stack_growth`의 내부 동작을 변경했을 때 syscall.c에서 변경사항이 반영되지 않습니다.