### PR TITLE
Issue 326 mmap munmap 구현

### DIFF
--- a/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
+++ b/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
@@ -377,6 +377,22 @@ make p3-mmap-results
 cat build/selected-results
 ```
 
+`p3-mmap-results`는 pass/FAIL 요약을 보는 타깃이다. 각 테스트의 `.result`를 만들기 위해 `.output`도 필요하면 생성되지만, 이미 최신이라고 판단되면 기존 `.output`을 그대로 쓰고 다시 실행하지 않는다.
+
+전체 mmap 테스트의 `.output`, `.result`, `selected-results`를 모두 만들고 싶으면:
+
+```bash
+cd /workspaces/pintos/pintos/vm
+make p3-mmap-all
+```
+
+전체 mmap 테스트의 `.output` 파일을 직접 만들고 싶으면:
+
+```bash
+cd /workspaces/pintos/pintos/vm
+make p3-mmap-outputs
+```
+
 mmap 테스트 하나만 실행:
 
 ```bash
@@ -442,7 +458,7 @@ rm -f build/tests/vm/mmap-read.output \
       build/tests/vm/mmap-read.errors \
       build/tests/vm/mmap-read.result
 
-make p3-mmap-one-result P3_MMAP_TEST=mmap-read
+make p3-mmap-one-output P3_MMAP_TEST=mmap-read
 ```
 
 결과 확인:

--- a/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
+++ b/docs/ai/003_Project3_빌드로_Project2_테스트_실행_가이드.md
@@ -358,6 +358,110 @@ make p3-stack-growth-regression-results
 cat build/selected-results
 ```
 
+## Project 3 mmap 테스트 실행
+
+Project 3의 mmap 관련 테스트만 확인하려면 `pintos/vm`에서 mmap 편의 타깃을 사용한다. 이 타깃도 `build/` 준비, 하위 디렉터리 생성, `TEST_SUBDIRS="tests/vm tests/threads"`, `FSDISK=10` 전달을 한 번에 처리한다.
+
+전체 mmap 테스트를 실행하고 pass/FAIL 요약까지 확인:
+
+```bash
+cd /workspaces/pintos/pintos/vm
+make p3-mmap-check
+```
+
+결과 파일만 갱신하고 요약 파일을 출력:
+
+```bash
+cd /workspaces/pintos/pintos/vm
+make p3-mmap-results
+cat build/selected-results
+```
+
+mmap 테스트 하나만 실행:
+
+```bash
+cd /workspaces/pintos/pintos/vm
+make p3-mmap-one P3_MMAP_TEST=mmap-read
+```
+
+단일 테스트의 `.result`만 만들고 바로 출력:
+
+```bash
+cd /workspaces/pintos/pintos/vm
+make p3-mmap-one-result P3_MMAP_TEST=mmap-read
+```
+
+단일 테스트의 `.output`만 만들고 바로 출력:
+
+```bash
+cd /workspaces/pintos/pintos/vm
+make p3-mmap-one-output P3_MMAP_TEST=mmap-read
+```
+
+테스트 이름은 짧은 이름 또는 전체 경로로 지정할 수 있다.
+
+```bash
+make p3-mmap-one P3_MMAP_TEST=mmap-write
+make p3-mmap-one P3_MMAP_TEST=tests/vm/mmap-write
+```
+
+포함되는 mmap 테스트 목록은 다음과 같다.
+
+```text
+tests/vm/mmap-read
+tests/vm/mmap-close
+tests/vm/mmap-unmap
+tests/vm/mmap-overlap
+tests/vm/mmap-twice
+tests/vm/mmap-write
+tests/vm/mmap-ro
+tests/vm/mmap-exit
+tests/vm/mmap-shuffle
+tests/vm/mmap-bad-fd
+tests/vm/mmap-clean
+tests/vm/mmap-inherit
+tests/vm/mmap-misalign
+tests/vm/mmap-null
+tests/vm/mmap-over-code
+tests/vm/mmap-over-data
+tests/vm/mmap-over-stk
+tests/vm/mmap-remove
+tests/vm/mmap-zero
+tests/vm/mmap-bad-fd2
+tests/vm/mmap-bad-fd3
+tests/vm/mmap-zero-len
+tests/vm/mmap-off
+tests/vm/mmap-bad-off
+tests/vm/mmap-kernel
+```
+
+이미 `.result`가 있어서 다시 실행되지 않으면 해당 테스트 산출물을 지운 뒤 다시 실행한다.
+
+```bash
+rm -f build/tests/vm/mmap-read.output \
+      build/tests/vm/mmap-read.errors \
+      build/tests/vm/mmap-read.result
+
+make p3-mmap-one-result P3_MMAP_TEST=mmap-read
+```
+
+결과 확인:
+
+```bash
+cat build/selected-results
+cat build/tests/vm/mmap-read.result
+cat build/tests/vm/mmap-read.output
+cat build/tests/vm/mmap-read.errors
+```
+
+커널 링크 단계에서 `_start_bss`, `_end_bss`, `start`, `_end_kernel_text`, `_end` 같은 심벌을 찾지 못하거나 relocation overflow가 나면 테스트 실패라기보다 빌드 산출물 또는 링크 스크립트 생성물이 꼬인 상태일 가능성이 높다. 이때는 한 번 깨끗하게 지우고 다시 실행한다.
+
+```bash
+cd /workspaces/pintos/pintos/vm
+make clean
+make p3-mmap-one P3_MMAP_TEST=mmap-read
+```
+
 ## Extra 2, dup2 테스트까지 포함
 
 Project 2 extra 테스트인 `dup2`까지 포함하려면 `TEST_SUBDIRS`에 `tests/userprog/dup2`를 추가하고, user program 컴파일 플래그에 `-DEXTRA2`를 준다.

--- a/pintos/.vscode/pintos-test-history.json
+++ b/pintos/.vscode/pintos-test-history.json
@@ -127,5 +127,132 @@
       "last_used": 1777817409.481,
       "last_action": "run"
     }
+  },
+  "vm": {
+    "tests/vm/mmap-read": {
+      "count": 3,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-close": {
+      "count": 3,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-unmap": {
+      "count": 7,
+      "last_used": 1779092256.363,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-overlap": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-twice": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-write": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-ro": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-exit": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-shuffle": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-bad-fd": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-clean": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-inherit": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-misalign": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-null": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-over-code": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-over-data": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-over-stk": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-remove": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-zero": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-bad-fd2": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-bad-fd3": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-zero-len": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-off": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-bad-off": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    },
+    "tests/vm/mmap-kernel": {
+      "count": 1,
+      "last_used": 1779084604.054,
+      "last_action": "run"
+    }
   }
 }

--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -7,6 +7,7 @@ struct page;
 enum vm_type;
 
 struct file_page {
+	void *aux;
 };
 
 void vm_file_init (void);

--- a/pintos/tests/vm/mmap-unmap.c
+++ b/pintos/tests/vm/mmap-unmap.c
@@ -17,8 +17,8 @@ test_main (void)
 
   CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
   CHECK ((map = mmap (ACTUAL, 0x2000, 0, handle, 0)) != MAP_FAILED, "mmap \"sample.txt\"");
-  msg ("memory is readable %d", *(int *) ACTUAL);
-  msg ("memory is readable %d", *(int *) ACTUAL + 0x1000);
+  msg ("memory is readable %d", *(int *) (ACTUAL));
+  msg ("memory is readable %d", *(int *) (ACTUAL + 0x1000));
 
   munmap (map);
 

--- a/pintos/tests/vm/mmap-unmap.ck
+++ b/pintos/tests/vm/mmap-unmap.ck
@@ -7,7 +7,7 @@ check_expected ([<<'EOF']);
 (mmap-unmap) open "sample.txt"
 (mmap-unmap) mmap "sample.txt"
 (mmap-unmap) memory is readable 540884285
-(mmap-unmap) memory is readable 540888381
+(mmap-unmap) memory is readable 0
 mmap-unmap: exit(-1)
 EOF
 pass;

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -121,6 +121,10 @@ page_fault (struct intr_frame *f) {
 		return;
 #endif
 
+	if (user) {
+		thread_exit ();
+	}
+
 	/* page fault를 센다. */
 	page_fault_cnt++;
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -172,14 +172,46 @@ syscall_handler (struct intr_frame *f)
 
 		
 		case SYS_MMAP:
+			f->R.rax = NULL;
+
 			void *addr = (void*) f->R.rdi;
 			size_t length = (size_t) f->R.rsi;
 			int writable = (int) f->R.rdx;
 			int fd = (int) f->R.r10;
 			struct file* file = fd_get (fd);
+			if (file == NULL) {
+				goto mmap_err;
+			}
 			off_t offset = (off_t) f->R.r8;
+			off_t file_bytes = file_length (file);
+			
+
+			if (
+				file_bytes == 0 ||
+				pg_ofs (addr) != 0 ||
+				addr == 0 ||
+				length == 0 ||
+				fd == 0 || fd == 1 ||
+				file_bytes < offset ||
+				offset % PGSIZE != 0 ||
+				!is_user_vaddr (addr)
+			) {
+				goto mmap_err;
+			}
+
+
+			for (off_t of = 0; of < length; of += PGSIZE) {
+				if (
+					spt_find_page (&thread_current ()->spt, addr + of) != NULL || 
+					!is_user_vaddr (addr + of)
+				) {
+					goto mmap_err;
+				}
+			}
 
 			f->R.rax = do_mmap (addr, length, writable, file, offset);
+
+		mmap_err:	
 			break;
 		
 		case SYS_MUNMAP:

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -247,28 +247,23 @@ validate_user_buffer (const void *buffer, size_t size, enum user_access access)
 			thread_exit ();
 		}
 
-		// PTE_P == 0 분기 분리 -> 왜 해주는거지???
+		// PTE_P == 0 분기 분리
 		struct page *page;
 		if ((*pte & PTE_P) == 0) {
-			// printf ("[debug] validate_user_buffer: non-present page "
-			// 		"addr=%p pte=%p pte_val=%llx access=%d\n",
-			// 		(const void *) i, (void *) pte,
-			// 		(unsigned long long) *pte, access);
-			// 스레드 구조체 내부에 다 있다...
 			page = spt_find_page (&thread_current ()->spt, i);
-			if (page == NULL && is_valid_stack_growth_request (false, NULL, i, page)) {
+			if (page != NULL) {
+				vm_claim_page (i);
+			}
+			else if (is_valid_stack_growth_request (false, NULL, i, page)) {
 				vm_alloc_page (VM_ANON, i, true);
 				vm_claim_page (i);
-			} else if (page == NULL) {
+			} else {
 				DBG ("validate_user_buffer: no spt entry\n");
 				DBG ("validate_user_buffer: page:%p, pte:%p, *pte:%lld\n", page, pte, *pte);
 
 				thread_exit ();
 			}
 		}
-
-		pte = pml4e_walk (thread_current ()->pml4,
-				(const uint64_t) i, false);
 
 		if (access == USER_ACCESS_WRITE && (*pte & PTE_P) == 1 && (*pte & PTE_W) == 0) {
 			DBG ("[debug] validate_user_buffer: write access denied "

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -170,6 +170,23 @@ syscall_handler (struct intr_frame *f)
 			break;
 		}
 
+		
+		case SYS_MMAP:
+			void *addr = (void*) f->R.rdi;
+			size_t length = (size_t) f->R.rsi;
+			int writable = (int) f->R.rdx;
+			int fd = (int) f->R.r10;
+			struct file* file = fd_get (fd);
+			off_t offset = (off_t) f->R.r8;
+
+
+
+			do_mmap (addr, length, writable, file, offset);
+			break;
+		
+		case SYS_MUNMAP:
+			break;
+
 		/* 아직 구현 안 한 syscall은 비정상 종료 */
 		default:
 			thread_exit ();

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -179,12 +179,11 @@ syscall_handler (struct intr_frame *f)
 			struct file* file = fd_get (fd);
 			off_t offset = (off_t) f->R.r8;
 
-
-
-			do_mmap (addr, length, writable, file, offset);
+			f->R.rax = do_mmap (addr, length, writable, file, offset);
 			break;
 		
 		case SYS_MUNMAP:
+			do_munmap ((void*) f->R.rdi);
 			break;
 
 		/* 아직 구현 안 한 syscall은 비정상 종료 */

--- a/pintos/vm/Makefile
+++ b/pintos/vm/Makefile
@@ -45,6 +45,8 @@ P3_MMAP_TESTS += tests/vm/mmap-zero-len
 P3_MMAP_TESTS += tests/vm/mmap-off
 P3_MMAP_TESTS += tests/vm/mmap-bad-off
 P3_MMAP_TESTS += tests/vm/mmap-kernel
+P3_MMAP_OUTPUTS = $(addsuffix .output,$(P3_MMAP_TESTS))
+P3_MMAP_RESULTS = $(addsuffix .result,$(P3_MMAP_TESTS))
 P3_MMAP_TEST ?= mmap-read
 P3_MMAP_TEST_PATH = $(if $(findstring /,$(P3_MMAP_TEST)),$(P3_MMAP_TEST),tests/vm/$(P3_MMAP_TEST))
 P2_FORK_DEPENDENT_TESTS = tests/userprog/fork-once
@@ -71,7 +73,7 @@ P2_USER_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_USER_TEST_SUBDIR
 P3_VM_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P3_VM_TEST_SUBDIRS) lib/user))
 
 .PHONY: p2-prepare-dirs p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results p2-fork-check p2-fork-results p2-fork-one p2-fork-one-result p2-fork-one-output
-.PHONY: p2-prepare-dirs p3-vm-prepare-dirs p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results p2-pointer-check p2-pointer-results p2-fork-check p2-fork-results p2-fork-one p2-fork-one-result p2-fork-one-output p3-pt-check p3-pt-results p3-stack-growth-check p3-stack-growth-results p3-stack-growth-regression-results p3-stack-one p3-stack-one-result p3-stack-one-output p3-mmap-check p3-mmap-results p3-mmap-one p3-mmap-one-result p3-mmap-one-output
+.PHONY: p2-prepare-dirs p3-vm-prepare-dirs p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results p2-pointer-check p2-pointer-results p2-fork-check p2-fork-results p2-fork-one p2-fork-one-result p2-fork-one-output p3-pt-check p3-pt-results p3-stack-growth-check p3-stack-growth-results p3-stack-growth-regression-results p3-stack-one p3-stack-one-result p3-stack-one-output p3-mmap-check p3-mmap-results p3-mmap-outputs p3-mmap-all p3-mmap-one p3-mmap-one-result p3-mmap-one-output
 
 p2-prepare-dirs: build/Makefile
 	mkdir -p $(P2_DIRS)
@@ -145,6 +147,13 @@ p3-mmap-check: p3-vm-prepare-dirs
 
 p3-mmap-results: p3-vm-prepare-dirs
 	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_MMAP_TESTS)" FSDISK=10
+	@cat build/selected-results
+
+p3-mmap-outputs: p3-vm-prepare-dirs
+	cd build && $(MAKE) $(P3_MMAP_OUTPUTS) TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" FSDISK=10
+
+p3-mmap-all: p3-vm-prepare-dirs
+	cd build && $(MAKE) $(P3_MMAP_OUTPUTS) $(P3_MMAP_RESULTS) selected-results TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_MMAP_TESTS)" FSDISK=10
 	@cat build/selected-results
 
 p3-mmap-one: p3-vm-prepare-dirs

--- a/pintos/vm/Makefile
+++ b/pintos/vm/Makefile
@@ -20,6 +20,33 @@ P3_STACK_GROWTH_REGRESSION_TESTS = tests/vm/page-merge-stk
 P3_STACK_GROWTH_REGRESSION_TESTS += tests/vm/mmap-over-stk
 P3_STACK_TEST ?= pt-grow-stack
 P3_STACK_TEST_PATH = $(if $(findstring /,$(P3_STACK_TEST)),$(P3_STACK_TEST),tests/vm/$(P3_STACK_TEST))
+P3_MMAP_TESTS = tests/vm/mmap-read
+P3_MMAP_TESTS += tests/vm/mmap-close
+P3_MMAP_TESTS += tests/vm/mmap-unmap
+P3_MMAP_TESTS += tests/vm/mmap-overlap
+P3_MMAP_TESTS += tests/vm/mmap-twice
+P3_MMAP_TESTS += tests/vm/mmap-write
+P3_MMAP_TESTS += tests/vm/mmap-ro
+P3_MMAP_TESTS += tests/vm/mmap-exit
+P3_MMAP_TESTS += tests/vm/mmap-shuffle
+P3_MMAP_TESTS += tests/vm/mmap-bad-fd
+P3_MMAP_TESTS += tests/vm/mmap-clean
+P3_MMAP_TESTS += tests/vm/mmap-inherit
+P3_MMAP_TESTS += tests/vm/mmap-misalign
+P3_MMAP_TESTS += tests/vm/mmap-null
+P3_MMAP_TESTS += tests/vm/mmap-over-code
+P3_MMAP_TESTS += tests/vm/mmap-over-data
+P3_MMAP_TESTS += tests/vm/mmap-over-stk
+P3_MMAP_TESTS += tests/vm/mmap-remove
+P3_MMAP_TESTS += tests/vm/mmap-zero
+P3_MMAP_TESTS += tests/vm/mmap-bad-fd2
+P3_MMAP_TESTS += tests/vm/mmap-bad-fd3
+P3_MMAP_TESTS += tests/vm/mmap-zero-len
+P3_MMAP_TESTS += tests/vm/mmap-off
+P3_MMAP_TESTS += tests/vm/mmap-bad-off
+P3_MMAP_TESTS += tests/vm/mmap-kernel
+P3_MMAP_TEST ?= mmap-read
+P3_MMAP_TEST_PATH = $(if $(findstring /,$(P3_MMAP_TEST)),$(P3_MMAP_TEST),tests/vm/$(P3_MMAP_TEST))
 P2_FORK_DEPENDENT_TESTS = tests/userprog/fork-once
 P2_FORK_DEPENDENT_TESTS += tests/userprog/fork-multiple
 P2_FORK_DEPENDENT_TESTS += tests/userprog/fork-recursive
@@ -44,7 +71,7 @@ P2_USER_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P2_USER_TEST_SUBDIR
 P3_VM_DIRS = $(sort $(addprefix build/,$(KERNEL_SUBDIRS) $(P3_VM_TEST_SUBDIRS) lib/user))
 
 .PHONY: p2-prepare-dirs p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results p2-fork-check p2-fork-results p2-fork-one p2-fork-one-result p2-fork-one-output
-.PHONY: p2-prepare-dirs p3-vm-prepare-dirs p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results p2-pointer-check p2-pointer-results p2-fork-check p2-fork-results p2-fork-one p2-fork-one-result p2-fork-one-output p3-pt-check p3-pt-results p3-stack-growth-check p3-stack-growth-results p3-stack-growth-regression-results p3-stack-one p3-stack-one-result p3-stack-one-output
+.PHONY: p2-prepare-dirs p3-vm-prepare-dirs p2-nofork-check p2-nofork-results p2-user-nofork-check p2-user-nofork-results p2-exec-basic-check p2-exec-basic-results p2-pointer-check p2-pointer-results p2-fork-check p2-fork-results p2-fork-one p2-fork-one-result p2-fork-one-output p3-pt-check p3-pt-results p3-stack-growth-check p3-stack-growth-results p3-stack-growth-regression-results p3-stack-one p3-stack-one-result p3-stack-one-output p3-mmap-check p3-mmap-results p3-mmap-one p3-mmap-one-result p3-mmap-one-output
 
 p2-prepare-dirs: build/Makefile
 	mkdir -p $(P2_DIRS)
@@ -112,3 +139,21 @@ p3-stack-one-result: p3-vm-prepare-dirs
 p3-stack-one-output: p3-vm-prepare-dirs
 	cd build && $(MAKE) $(P3_STACK_TEST_PATH).output TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" FSDISK=10
 	@cat build/$(P3_STACK_TEST_PATH).output
+
+p3-mmap-check: p3-vm-prepare-dirs
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_MMAP_TESTS)" FSDISK=10
+
+p3-mmap-results: p3-vm-prepare-dirs
+	cd build && $(MAKE) selected-results TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_MMAP_TESTS)" FSDISK=10
+	@cat build/selected-results
+
+p3-mmap-one: p3-vm-prepare-dirs
+	cd build && $(MAKE) selected-check TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" INCLUDE_TESTS="$(P3_MMAP_TEST_PATH)" FSDISK=10
+
+p3-mmap-one-result: p3-vm-prepare-dirs
+	cd build && $(MAKE) $(P3_MMAP_TEST_PATH).result TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" FSDISK=10
+	@cat build/$(P3_MMAP_TEST_PATH).result
+
+p3-mmap-one-output: p3-vm-prepare-dirs
+	cd build && $(MAKE) $(P3_MMAP_TEST_PATH).output TEST_SUBDIRS="$(P3_VM_TEST_SUBDIRS)" FSDISK=10
+	@cat build/$(P3_MMAP_TEST_PATH).output

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -70,10 +70,14 @@ lazy_load_file (struct page *page, void *aux)
 	// free (aux);
 
 	void* kpage = page->frame->kva;
-	
-	if (!file_read_at (file, kpage, read_bytes, ofs)) {
+
+	lock_acquire (&filesys_lock);
+	if (read_bytes > 0 && !file_read_at (file, kpage, read_bytes, ofs)) {
+		lock_release (&filesys_lock);
+		DBG ("lazy_load_file: file read at 실패... \n");
 		return false;
 	}
+	lock_release (&filesys_lock);
 	memset (kpage + read_bytes, 0, zero_bytes);
 
 	return true;

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -169,6 +169,10 @@ do_mmap (void *addr, size_t length, int writable,
 	ASSERT (ofs % PGSIZE == 0);
 
 
+	struct file *new_file = file_reopen (file); // TODO. 각 page 마다 file 구조체를 새롭게 만들지 말고, 첫 번째 page 에만 만드는 식으로 최적화를 할 수 있을 것 같아요...
+	if (new_file == NULL) {
+		return NULL;
+	}
 
 	while (read_bytes > 0 || zero_bytes > 0)
 	{

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -5,6 +5,8 @@
 #include "filesys/file.h"
 #include "debug_log.h"
 #include "userprog/syscall.h"
+#include "threads/pte.h"
+#include "threads/mmu.h"
 
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
@@ -39,7 +41,7 @@ file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 	page->operations = &file_ops;
 
 	struct file_page *file_page = &page->file;
-	page->file.aux = aux; 
+	file_page->aux = aux; 
 }
 
 /* 파일에서 내용을 읽어 페이지를 swap in 한다. */
@@ -59,6 +61,7 @@ struct lazy_load_file_aux {
 	off_t ofs; // 실행 파일의 어느 위치부터(숫자값) 읽을지
 	uint32_t read_bytes; // 이 page file에서 몇바이트 읽을지
 	uint32_t zero_bytes; // 채워지지 않은 만큼 0으로 채워놓음
+	int pg_cnt; // 몇 페이지나 할당할 것인지 (length에 의해 결정됨)
 };
 
 /* file-backed page를 파괴한다. PAGE는 호출자가 해제한다. 
@@ -71,6 +74,16 @@ static void
 file_backed_destroy (struct page *page) {
 	struct file_page *file_page = &page->file;
 
+	uint64_t *pte = pml4e_walk (thread_current()->pml4, page->va, 0);
+	DBG ("[file_backed_destroy] page : %p\n", page);
+	// DBG ("[file_backed_destroy] frame->kva : %p\n", page->frame->kva);
+	// DBG ("[file_backed_destroy] pte : %p, *pte = %p\n", pte, *pte);
+
+	// if (*pte & PTE_P == 1)
+	// 	palloc_free_page ((void*) PTE_ADDR(pte));
+	pml4_clear_page (thread_current ()->pml4, page->va);
+	page->frame = NULL;
+	
 }
 
 
@@ -87,6 +100,9 @@ lazy_load_file (struct page *page, void *aux)
 	// free (aux);
 
 	void* kpage = page->frame->kva;
+	
+	DBG ("[lazy_load_file] frame->kva : %p\n", page->frame->kva);
+
 
 	lock_acquire (&filesys_lock);
 	if (read_bytes > 0 && !file_read_at (file, kpage, read_bytes, ofs)) {
@@ -117,11 +133,22 @@ do_mmap (void *addr, size_t length, int writable,
 	read_bytes = file_length (file);
 	lock_release (&filesys_lock);
 
+	DBG ("[do_mmap] read_bytes is %d, zero_bytes is %d...\n", read_bytes, zero_bytes);
+
 	if (read_bytes > length) { // filesize 가 length보다 더 큰 경우
 		read_bytes = length;
 	}
 	zero_bytes += length - read_bytes;
-	zero_bytes += PGSIZE - (length % PGSIZE);
+	DBG ("[do_mmap] read_bytes is %d, zero_bytes is %d...\n", read_bytes, zero_bytes);
+
+	if (length % PGSIZE > 0) {
+		zero_bytes += PGSIZE - (length % PGSIZE);
+	}
+	
+	DBG ("[do_mmap] read_bytes is %d, zero_bytes is %d...\n", read_bytes, zero_bytes);
+
+
+	int pg_cnt = (length / PGSIZE) + (length % PGSIZE == 0 ? 0 : 1);
 	
 	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
 	ASSERT (pg_ofs(upage) == 0);
@@ -129,6 +156,7 @@ do_mmap (void *addr, size_t length, int writable,
 
 	while (read_bytes > 0 || zero_bytes > 0)
 	{
+		DBG ("[do_map] in while... %d, %d\n", read_bytes, zero_bytes);
 		/* 이 페이지를 어떻게 채울지 계산하세요.
 		 * FILE에서 PAGE_READ_BYTES 바이트를 읽고
 		 * 마지막 PAGE_ZERO_BYTES 바이트는 0으로 채웁니다. */
@@ -153,8 +181,10 @@ do_mmap (void *addr, size_t length, int writable,
 		aux->ofs = ofs;
 		aux->read_bytes = page_read_bytes;
 		aux->zero_bytes = page_zero_bytes;
+		aux->pg_cnt = pg_cnt;
 		
 
+		DBG ("make spt entry, %p...\n", upage);
 		if (!vm_alloc_page_with_initializer (VM_FILE, upage,
 											writable, lazy_load_file, aux))
 		{
@@ -168,6 +198,7 @@ do_mmap (void *addr, size_t length, int writable,
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
 		ofs += page_read_bytes;
+		pg_cnt = -1; // 첫 시작 페이지에만 적어놓는다. 다른 페이지에는 적어두지 않는다.
 	}
 	return addr;
 }
@@ -175,5 +206,25 @@ do_mmap (void *addr, size_t length, int writable,
 /* munmap을 수행한다 */
 void
 do_munmap (void *addr) {
+	struct page* page = spt_find_page (&thread_current ()->spt, addr);
+	struct lazy_load_file_aux *aux = (struct lazy_load_file_aux *)(page->file.aux);
+	int pg_cnt = aux->pg_cnt;
+
+	DBG ("[do_mnumap] page: 		%p\n", page);
+	DBG ("[do_mnumap] page null?: 	%d\n", page == NULL);
+	DBG ("[do_mnumap] current type: %d\n", page->operations->type);
+	DBG ("[do_mnumap] pg_cnt: 		%d\n", pg_cnt);
+
+	if (pg_cnt == -1) {
+		// TODO. validation part를 바깥으로 빼야 하나?
+		DBG ("시작 페이지가 아닙니다. 몇 페이지나 할당 해제해야 하는지 알 수 없어요...\n ");
+		return;
+	}
+
+	for (int i = 0; i < pg_cnt; i++, addr += PGSIZE) {
+		page = spt_find_page (&thread_current ()->spt, addr);
+		DBG ("[do_mnumap] call destroy...\n");
+		destroy (page);
+	}
 
 }

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -78,7 +78,7 @@ file_backed_destroy (struct page *page) {
 	struct lazy_load_file_aux *aux = page->file.aux;
 	struct file* file = aux->file;
 	off_t ofs = aux->ofs;
-	// uint32_t read_bytes = aux->read_bytes;
+	uint32_t read_bytes = aux->read_bytes;
 	// uint32_t zero_bytes = aux->zero_bytes;
 	uint64_t *pte = pml4e_walk (thread_current()->pml4, page->va, 0);
 
@@ -87,7 +87,7 @@ file_backed_destroy (struct page *page) {
 		// TODO. write back을 해준다.... 어떻게 해주지???
 		lock_acquire (&filesys_lock);
 
-		file_write_at (file, page->va, PGSIZE, ofs);
+		file_write_at (file, page->va, read_bytes, ofs);
 		lock_release (&filesys_lock);
 	}
 

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -124,8 +124,11 @@ do_mmap (void *addr, size_t length, int writable,
 		}
 		
 
-
-		aux->file = file;
+		struct file *new_file = file_reopen (file); // TODO. 각 page 마다 file 구조체를 새롭게 만들지 말고, 첫 번째 page 에만 만드는 식으로 최적화를 할 수 있을 것 같아요...
+		if (new_file == NULL) {
+			free (aux); // TODO. 이런 예외 상황에서 기존에 만들어두었던 다른 메모리 자원들도 회수해야 하지 않나?
+		}
+		aux->file = new_file;
 		aux->ofs = ofs;
 		aux->read_bytes = page_read_bytes;
 		aux->zero_bytes = page_zero_bytes;

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -18,12 +18,19 @@ static const struct page_operations file_ops = {
 	.type = VM_FILE,
 };
 
-/* file vm의 초기화자 */
+/* file vm의 초기화자 
+	파일 기반 페이지(file-backed page) 서브시스템을 초기화합니다. 
+	이 함수에서 파일 기반 페이지와 관련된 모든 것을 설정할 수 있습니다.
+*/
 void
 vm_file_init (void) {
 }
 
-/* file-backed page를 초기화한다 */
+/* file-backed page를 초기화한다 
+	파일 기반 페이지(file-backed page)를 초기화합니다. 
+	이 함수는 먼저 page->operations에서 파일 기반 페이지의 핸들러(handler)를 설정합니다. 
+	메모리를 뒷받침하는 파일 같은 일부 정보를 page 구조체에 업데이트할 수 있습니다.
+*/
 bool
 file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 	/* handler를 설정한다 */
@@ -44,18 +51,24 @@ file_backed_swap_out (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
 }
 
-/* file-backed page를 파괴한다. PAGE는 호출자가 해제한다. */
-static void
-file_backed_destroy (struct page *page) {
-	struct file_page *file_page UNUSED = &page->file;
-}
-
 struct lazy_load_file_aux {
 	struct file *file; // 어느 실행 파일을 읽을지
 	off_t ofs; // 실행 파일의 어느 위치부터(숫자값) 읽을지
 	uint32_t read_bytes; // 이 page file에서 몇바이트 읽을지
 	uint32_t zero_bytes; // 채워지지 않은 만큼 0으로 채워놓음
 };
+
+/* file-backed page를 파괴한다. PAGE는 호출자가 해제한다. 
+	연관된 파일을 닫아 파일 기반 페이지(file-backed page)를 파괴합니다. 
+	내용이 더티(dirty)이면 변경 사항을 파일에 다시 기록해야 합니다. 
+	이 함수에서 page 구조체를 해제할 필요는 없습니다. 
+	file_backed_destroy의 호출자가 이를 처리해야 합니다.
+*/
+static void
+file_backed_destroy (struct page *page) {
+	struct file_page *file_page UNUSED = &page->file;
+}
+
 
 static bool
 lazy_load_file (struct page *page, void *aux)
@@ -158,4 +171,5 @@ do_mmap (void *addr, size_t length, int writable,
 /* munmap을 수행한다 */
 void
 do_munmap (void *addr) {
+
 }

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -168,10 +168,7 @@ do_mmap (void *addr, size_t length, int writable,
 	ASSERT (pg_ofs(upage) == 0);
 	ASSERT (ofs % PGSIZE == 0);
 
-	struct file *new_file = file_reopen (file); // TODO. 각 page 마다 file 구조체를 새롭게 만들지 말고, 첫 번째 page 에만 만드는 식으로 최적화를 할 수 있을 것 같아요...
-	if (new_file == NULL) {
-		return NULL;
-	}
+
 
 	while (read_bytes > 0 || zero_bytes > 0)
 	{
@@ -190,9 +187,12 @@ do_mmap (void *addr, size_t length, int writable,
 		if (aux == NULL) {
 			return NULL;
 		}
+
+		struct file *new_file = file_reopen (file); // TODO. 각 page 마다 file 구조체를 새롭게 만들지 말고, 첫 번째 page 에만 만드는 식으로 최적화를 할 수 있을 것 같아요...
+		if (new_file == NULL) {
+			return NULL;
+		}
 		
-
-
 		aux->file = new_file;
 		aux->ofs = ofs;
 		aux->read_bytes = page_read_bytes;

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -4,6 +4,7 @@
 #include "threads/vaddr.h"
 #include "filesys/file.h"
 #include "debug_log.h"
+#include "userprog/syscall.h"
 
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
@@ -91,11 +92,14 @@ do_mmap (void *addr, size_t length, int writable,
 	uint32_t zero_bytes;
 	// read_bytes, zero_bytes 계산
 	// read_bytes = min (length, filesize)
+	lock_acquire (&filesys_lock);
 	read_bytes = file_length (file); // TODO. file 을 쓸 때 락을 걸어야 하나요??
-	if (read_bytes < length) {
+	lock_release (&filesys_lock);
+	
+	if (read_bytes > length) {
 		read_bytes = length;
 	}
-	zero_bytes = read_bytes % PGSIZE;
+	zero_bytes = read_bytes % PGSIZE;  // TODO. 이렇게 되면 zero_bytes가 
 	
 	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
 	ASSERT (pg_ofs(upage) == 0);

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -75,9 +75,7 @@ file_backed_destroy (struct page *page) {
 	struct file_page *file_page = &page->file;
 
 	uint64_t *pte = pml4e_walk (thread_current()->pml4, page->va, 0);
-	DBG ("[file_backed_destroy] page : %p\n", page);
-	// DBG ("[file_backed_destroy] frame->kva : %p\n", page->frame->kva);
-	// DBG ("[file_backed_destroy] pte : %p, *pte = %p\n", pte, *pte);
+
 
 	// if (*pte & PTE_P == 1)
 	// 	palloc_free_page ((void*) PTE_ADDR(pte));
@@ -210,10 +208,6 @@ do_munmap (void *addr) {
 	struct lazy_load_file_aux *aux = (struct lazy_load_file_aux *)(page->file.aux);
 	int pg_cnt = aux->pg_cnt;
 
-	DBG ("[do_mnumap] page: 		%p\n", page);
-	DBG ("[do_mnumap] page null?: 	%d\n", page == NULL);
-	DBG ("[do_mnumap] current type: %d\n", page->operations->type);
-	DBG ("[do_mnumap] pg_cnt: 		%d\n", pg_cnt);
 
 	if (pg_cnt == -1) {
 		// TODO. validation part를 바깥으로 빼야 하나?

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -224,7 +224,7 @@ do_munmap (void *addr) {
 	for (int i = 0; i < pg_cnt; i++, addr += PGSIZE) {
 		page = spt_find_page (&thread_current ()->spt, addr);
 		DBG ("[do_mnumap] call destroy...\n");
-		destroy (page);
+		spt_remove_page (&thread_current ()->spt, page);
 	}
 
 }

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -169,10 +169,7 @@ do_mmap (void *addr, size_t length, int writable,
 	ASSERT (ofs % PGSIZE == 0);
 
 
-	struct file *new_file = file_reopen (file); // TODO. 각 page 마다 file 구조체를 새롭게 만들지 말고, 첫 번째 page 에만 만드는 식으로 최적화를 할 수 있을 것 같아요...
-	if (new_file == NULL) {
-		return NULL;
-	}
+
 
 	while (read_bytes > 0 || zero_bytes > 0)
 	{

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -88,23 +88,23 @@ do_mmap (void *addr, size_t length, int writable,
 	// load_segment 하드 코딩 복사
 	off_t ofs = offset;
 	uint8_t *upage = addr;
-	uint32_t read_bytes;
-	uint32_t zero_bytes;
+	uint32_t read_bytes = 0;
+	uint32_t zero_bytes = 0;
 	// read_bytes, zero_bytes 계산
-	// read_bytes = min (length, filesize)
+	// read_bytes = : 읽어야 하는 총 bytes 수 
 	lock_acquire (&filesys_lock);
-	read_bytes = file_length (file); // TODO. file 을 쓸 때 락을 걸어야 하나요??
+	read_bytes = file_length (file);
 	lock_release (&filesys_lock);
-	
-	if (read_bytes > length) {
+
+	if (read_bytes > length) { // filesize 가 length보다 더 큰 경우
 		read_bytes = length;
 	}
-	zero_bytes = read_bytes % PGSIZE;  // TODO. 이렇게 되면 zero_bytes가 
+	zero_bytes += length - read_bytes;
+	zero_bytes += PGSIZE - (length % PGSIZE);
 	
 	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
 	ASSERT (pg_ofs(upage) == 0);
 	ASSERT (ofs % PGSIZE == 0);
-
 
 	while (read_bytes > 0 || zero_bytes > 0)
 	{
@@ -123,6 +123,8 @@ do_mmap (void *addr, size_t length, int writable,
 			return NULL;
 		}
 		
+
+
 		aux->file = file;
 		aux->ofs = ofs;
 		aux->read_bytes = page_read_bytes;

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -92,8 +92,9 @@ file_backed_destroy (struct page *page) {
 	if (pte != NULL && ((*pte) & PTE_P != 0))
 		palloc_free_page (ptov(PTE_ADDR (*pte)));
 	pml4_clear_page (thread_current ()->pml4, page->va);
-	page->frame = NULL; // TODO. 메모리 누수
 	
+	file_close (file);
+	free (aux);
 }
 
 
@@ -230,7 +231,6 @@ do_munmap (void *addr) {
 
 	for (int i = 0; i < pg_cnt; i++, addr += PGSIZE) {
 		page = spt_find_page (&thread_current ()->spt, addr);
-		DBG ("[do_mnumap] call destroy...\n");
 		spt_remove_page (&thread_current ()->spt, page);
 	}
 

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -94,7 +94,7 @@ file_backed_destroy (struct page *page) {
 	if (pte != NULL && ((*pte) & PTE_P != 0))
 		palloc_free_page (ptov(PTE_ADDR (*pte)));
 	pml4_clear_page (thread_current ()->pml4, page->va);
-	
+
 	file_close (file);
 	free (aux);
 }
@@ -168,6 +168,11 @@ do_mmap (void *addr, size_t length, int writable,
 	ASSERT (pg_ofs(upage) == 0);
 	ASSERT (ofs % PGSIZE == 0);
 
+	struct file *new_file = file_reopen (file); // TODO. 각 page 마다 file 구조체를 새롭게 만들지 말고, 첫 번째 page 에만 만드는 식으로 최적화를 할 수 있을 것 같아요...
+	if (new_file == NULL) {
+		return NULL;
+	}
+
 	while (read_bytes > 0 || zero_bytes > 0)
 	{
 		DBG ("[do_map] in while... %d, %d\n", read_bytes, zero_bytes);
@@ -187,10 +192,7 @@ do_mmap (void *addr, size_t length, int writable,
 		}
 		
 
-		struct file *new_file = file_reopen (file); // TODO. 각 page 마다 file 구조체를 새롭게 만들지 말고, 첫 번째 page 에만 만드는 식으로 최적화를 할 수 있을 것 같아요...
-		if (new_file == NULL) {
-			free (aux); // TODO. 이런 예외 상황에서 기존에 만들어두었던 다른 메모리 자원들도 회수해야 하지 않나?
-		}
+
 		aux->file = new_file;
 		aux->ofs = ofs;
 		aux->read_bytes = page_read_bytes;
@@ -233,6 +235,9 @@ do_munmap (void *addr) {
 
 	for (int i = 0; i < pg_cnt; i++, addr += PGSIZE) {
 		page = spt_find_page (&thread_current ()->spt, addr);
+		if (page == NULL || page_get_type (page) != VM_FILE) {
+			return NULL;
+		}
 		spt_remove_page (&thread_current ()->spt, page);
 	}
 

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -42,6 +42,8 @@ file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 
 	struct file_page *file_page = &page->file;
 	file_page->aux = aux; 
+
+	return true;
 }
 
 /* 파일에서 내용을 읽어 페이지를 swap in 한다. */

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -76,11 +76,10 @@ file_backed_destroy (struct page *page) {
 
 	uint64_t *pte = pml4e_walk (thread_current()->pml4, page->va, 0);
 
-
-	// if (*pte & PTE_P == 1)
-	// 	palloc_free_page ((void*) PTE_ADDR(pte));
+	if (pte != NULL && ((*pte) & PTE_P != 0))
+		palloc_free_page (ptov(PTE_ADDR (*pte)));
 	pml4_clear_page (thread_current ()->pml4, page->va);
-	page->frame = NULL;
+	page->frame = NULL; // TODO. 메모리 누수
 	
 }
 

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -33,10 +33,13 @@ vm_file_init (void) {
 */
 bool
 file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
+	/* 먼저 가져와라. page_initialize가 값을 덮어쓸 수 있다 */
+	void *aux = page->uninit.aux;
 	/* handler를 설정한다 */
 	page->operations = &file_ops;
 
 	struct file_page *file_page = &page->file;
+	page->file.aux = aux; 
 }
 
 /* 파일에서 내용을 읽어 페이지를 swap in 한다. */
@@ -66,7 +69,8 @@ struct lazy_load_file_aux {
 */
 static void
 file_backed_destroy (struct page *page) {
-	struct file_page *file_page UNUSED = &page->file;
+	struct file_page *file_page = &page->file;
+
 }
 
 

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -1,6 +1,9 @@
 /* file.c: memory backed file object(mmaped object)의 구현. */
 
 #include "vm/vm.h"
+#include "threads/vaddr.h"
+#include "filesys/file.h"
+#include "debug_log.h"
 
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
@@ -46,10 +49,97 @@ file_backed_destroy (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
 }
 
+struct lazy_load_file_aux {
+	struct file *file; // 어느 실행 파일을 읽을지
+	off_t ofs; // 실행 파일의 어느 위치부터(숫자값) 읽을지
+	uint32_t read_bytes; // 이 page file에서 몇바이트 읽을지
+	uint32_t zero_bytes; // 채워지지 않은 만큼 0으로 채워놓음
+};
+
+static bool
+lazy_load_file (struct page *page, void *aux)
+{
+	if (aux == NULL) {
+		return false;
+	}
+	struct file *file = ((struct lazy_load_file_aux *) aux)->file;
+	off_t ofs = ((struct lazy_load_file_aux *) aux)->ofs;
+	uint32_t read_bytes = ((struct lazy_load_file_aux *) aux)->read_bytes;
+	uint32_t zero_bytes = ((struct lazy_load_file_aux *) aux)->zero_bytes;
+	// free (aux);
+
+	void* kpage = page->frame->kva;
+	
+	if (!file_read_at (file, kpage, read_bytes, ofs)) {
+		return false;
+	}
+	memset (kpage + read_bytes, 0, zero_bytes);
+
+	return true;
+}
+
 /* mmap을 수행한다 */
 void *
 do_mmap (void *addr, size_t length, int writable,
 		struct file *file, off_t offset) {
+	// TODO. validate request ... 
+
+	// load_segment 하드 코딩 복사
+	off_t ofs = offset;
+	uint8_t *upage = addr;
+	uint32_t read_bytes;
+	uint32_t zero_bytes;
+	// read_bytes, zero_bytes 계산
+	// read_bytes = min (length, filesize)
+	read_bytes = file_length (file); // TODO. file 을 쓸 때 락을 걸어야 하나요??
+	if (read_bytes < length) {
+		read_bytes = length;
+	}
+	zero_bytes = read_bytes % PGSIZE;
+	
+	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
+	ASSERT (pg_ofs(upage) == 0);
+	ASSERT (ofs % PGSIZE == 0);
+
+
+	while (read_bytes > 0 || zero_bytes > 0)
+	{
+		/* 이 페이지를 어떻게 채울지 계산하세요.
+		 * FILE에서 PAGE_READ_BYTES 바이트를 읽고
+		 * 마지막 PAGE_ZERO_BYTES 바이트는 0으로 채웁니다. */
+		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+		size_t page_zero_bytes = PGSIZE - page_read_bytes;
+
+		/* Project 3 구현 시 struct lazy_load_segment_aux를 page마다 만들어
+		 * file, offset, read/zero byte 수를 넘긴다. 이렇게 하면 lazy load와
+		 * mmap 모두 file position 공유 없이 file_read_at() 기반으로 이어갈 수 있다. */
+		struct lazy_load_file_aux *aux = malloc (sizeof (struct lazy_load_file_aux));
+
+		if (aux == NULL) {
+			return NULL;
+		}
+		
+		aux->file = file;
+		aux->ofs = ofs;
+		aux->read_bytes = page_read_bytes;
+		aux->zero_bytes = page_zero_bytes;
+		
+
+		if (!vm_alloc_page_with_initializer (VM_FILE, upage,
+											writable, lazy_load_file, aux))
+		{
+			free (aux);
+			return NULL;
+		}
+			
+
+		/* 다음으로 진행합니다. */
+		read_bytes -= page_read_bytes;
+		zero_bytes -= page_zero_bytes;
+		upage += PGSIZE;
+		ofs += page_read_bytes;
+	}
+	return addr;
 }
 
 /* munmap을 수행한다 */

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -73,8 +73,21 @@ struct lazy_load_file_aux {
 static void
 file_backed_destroy (struct page *page) {
 	struct file_page *file_page = &page->file;
-
+	struct lazy_load_file_aux *aux = page->file.aux;
+	struct file* file = aux->file;
+	off_t ofs = aux->ofs;
+	// uint32_t read_bytes = aux->read_bytes;
+	// uint32_t zero_bytes = aux->zero_bytes;
 	uint64_t *pte = pml4e_walk (thread_current()->pml4, page->va, 0);
+
+	if (pml4_is_dirty (thread_current ()->pml4, page->va)) {
+	// if (pte != NULL && (*pte & PTE_D)) {
+		// TODO. write back을 해준다.... 어떻게 해주지???
+		lock_acquire (&filesys_lock);
+
+		file_write_at (file, page->va, PGSIZE, ofs);
+		lock_release (&filesys_lock);
+	}
 
 	if (pte != NULL && ((*pte) & PTE_P != 0))
 		palloc_free_page (ptov(PTE_ADDR (*pte)));
@@ -110,6 +123,7 @@ lazy_load_file (struct page *page, void *aux)
 	lock_release (&filesys_lock);
 	memset (kpage + read_bytes, 0, zero_bytes);
 
+	pml4_set_dirty (thread_current ()->pml4, page->va, 0);
 	return true;
 }
 

--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -45,19 +45,11 @@ uninit_new (struct page *page, void *va, vm_initializer *init,
 /* 첫 page fault에서 페이지를 초기화한다 */
 static bool
 uninit_initialize (struct page *page, void *kva) {
-	DBG ("uninit_initialize: start\n");
 	struct uninit_page *uninit = &page->uninit;
-	DBG ("uninit_initialize: page fault??\n");
 
 	/* 먼저 가져와라. page_initialize가 값을 덮어쓸 수 있다 */
 	vm_initializer *init = uninit->init;
 	void *aux = uninit->aux;
-
-	DBG ("uninit_initialize: variable 가져오기 끝... 그럼 아래 initializer 호출에서 문제가 발생한거에요.\n");
-
-	DBG ("anon page initializer 함수 포인터는... %p\n", anon_initializer);
-	DBG ("anon swap in 함수 포인터는...			 %p\n", anon_initializer);
-	DBG ("vm_initializer(init) 함수 포인터		%p\n", init);
 	
 	/* TODO: 이 함수를 수정해야 할 수도 있다. */
 	return uninit->page_initializer (page, uninit->type, kva) &&

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -86,6 +86,8 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 			break;
 		
 		default:
+			DBG ("no valid type...\n");
+			PANIC ("TODO?");
 			break;
 		}
 		struct page *page = malloc (sizeof (struct page));
@@ -104,7 +106,7 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		return true;
 	}
 err:
-printf ("아마 spt가 제대로 kill 되지 않은 문제일 수 있어요. ...===\n");
+	printf ("아마 spt가 제대로 kill 되지 않은 문제일 수 있어요. ...===\n");
 	return false;
 }
 
@@ -229,6 +231,7 @@ is_valid_stack_growth_request (bool user, struct intr_frame* f, void* addr, stru
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
+	DBG ("[vm_try_handle_fault] page fault occurs...\n");
 	if (!not_present) {
 		DBG ("not present, DIE...	\n");
 		return false;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -142,6 +142,7 @@ spt_insert_page (struct supplemental_page_table *spt,
 
 void
 spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
+	hash_delete (&spt->table, &page->hash_elem);
 	vm_dealloc_page (page);
 	return true;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -144,7 +144,7 @@ void
 spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
 	hash_delete (&spt->table, &page->hash_elem);
 	vm_dealloc_page (page);
-	return true;
+	return;
 }
 
 /* evict될 struct frame을 가져온다. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -384,7 +384,10 @@ supplemental_page_table_copy (struct supplemental_page_table *dst,
 void
 vm_hash_destroy_func (struct hash_elem *e, void *aux UNUSED) {
 	struct page * page = hash_entry (e, struct page, hash_elem);
-
+	// if (page->operations->type == VM_FILE && page->file.aux->pg_cnt != -1) {
+	// do_munmap(page->va);
+	// }
+	destroy (page);
 	free (page->frame);
 	free (page);
 }


### PR DESCRIPTION
  ## 작업 내용

  - `mmap` / `munmap` 시스템 콜을 구현했습니다.
  - file-backed page의 lazy loading 흐름을 정리했습니다.
  - `mmap`된 파일이 이후 `close`되더라도 lazy loading이 가능하도록 file 참조를 분리했습니다.
  - `munmap` 시 SPT에서 page를 제거하고, file-backed page destroy 경로를 통해 자원을 정리하도록 수정했습니다.
  - dirty bit가 설정된 mmap page는 해제 시 파일에 write-back되도록 처리했습니다.
  - 프로세스 종료 시 SPT에 남아 있는 page의 destroy 함수가 호출되도록 정리했습니다.
  - page table entry 정리 과정에서 잘못된 frame 해제로 double free가 발생하지 않도록 수정했습니다.
  - mmap 관련 테스트 실행을 위한 Makefile target을 보강했습니다.

  ## 테스트

  - mmap 관련 테스트 전체 통과
  - 기존 회귀 테스트 전체 통과

  ## 리뷰 포인트

  - `mmap` 예외 처리 조건이 과제 요구사항과 맞는지
  - `munmap` 및 프로세스 종료 시 file-backed page 정리 책임이 일관적인지
  - dirty page write-back 시점과 page table 정리 순서가 적절한지

  Closes #326 